### PR TITLE
Support versions of Go down to Go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: go
-# TODO(light): Enable Go 1.6 (#2).
 go:
+- 1.6
 - 1.x

--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -28,7 +28,6 @@ package cmp
 import (
 	"fmt"
 	"reflect"
-	"sort"
 )
 
 // BUG: Maps with keys containing NaN values cannot be properly compared due to
@@ -126,10 +125,13 @@ func newState(opts []Option) *state {
 	for _, opt := range opts {
 		s.processOption(opt)
 	}
-	// Sort options such that Ignore options are evaluated first.
-	sort.SliceStable(s.opts, func(i, j int) bool {
-		return s.opts[i].op == nil && s.opts[j].op != nil
-	})
+	// Move Ignore options to the front so that they are evaluated first.
+	for i, j := 0, 0; i < len(s.opts); i++ {
+		if s.opts[i].op == nil {
+			s.opts[i], s.opts[j] = s.opts[j], s.opts[i]
+			j++
+		}
+	}
 	return s
 }
 

--- a/cmp/example_test.go
+++ b/cmp/example_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -128,56 +127,6 @@ func ExampleOption_equalEmpty() {
 	fmt.Println(cmp.Equal(x, y, opt))
 	fmt.Println(cmp.Equal(y, z, opt))
 	fmt.Println(cmp.Equal(z, x, opt))
-
-	// Output:
-	// true
-	// false
-	// false
-}
-
-// Equal compares map keys using Go's == operator. To use Equal itself on
-// map keys, transform the map into something else, like a slice of
-// key-value pairs.
-func ExampleOption_transformMap() {
-	type KV struct {
-		K time.Time
-		V string
-	}
-	// This transformer flattens the map as a slice of sorted key-value pairs.
-	// We can now safely rely on the Time.Equal to be used for equality.
-	trans := cmp.Transformer("", func(m map[time.Time]string) (s []KV) {
-		for k, v := range m {
-			s = append(s, KV{k, v})
-		}
-		sort.Slice(s, func(i, j int) bool {
-			return s[i].K.Before(s[j].K)
-		})
-		return s
-	})
-
-	t1 := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	t2 := time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)
-	t3 := time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC)
-
-	x := map[time.Time]string{
-		t1.In(time.UTC): "0th birthday",
-		t2.In(time.UTC): "1st birthday",
-		t3.In(time.UTC): "2nd birthday",
-	}
-	y := map[time.Time]string{
-		t1.In(time.Local): "0th birthday",
-		t2.In(time.Local): "1st birthday",
-		t3.In(time.Local): "2nd birthday",
-	}
-	z := map[time.Time]string{
-		time.Now(): "a long long",
-		time.Now(): "time ago",
-		time.Now(): "in a galaxy far far away",
-	}
-
-	fmt.Println(cmp.Equal(x, y, trans))
-	fmt.Println(cmp.Equal(y, z, trans))
-	fmt.Println(cmp.Equal(z, x, trans))
 
 	// Output:
 	// true

--- a/cmp/options_test.go
+++ b/cmp/options_test.go
@@ -185,7 +185,7 @@ func TestOptionPanic(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		t.Run(tt.label, func(t *testing.T) {
+		tRun(t, tt.label, func(t *testing.T) {
 			var gotPanic string
 			func() {
 				defer func() {
@@ -213,5 +213,19 @@ func TestOptionPanic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TODO: Delete this hack when we drop Go1.6 support.
+func tRun(t *testing.T, name string, f func(t *testing.T)) {
+	type runner interface {
+		Run(string, func(t *testing.T)) bool
+	}
+	var ti interface{} = t
+	if r, ok := ti.(runner); ok {
+		r.Run(name, f)
+	} else {
+		t.Logf("Test: %s", name)
+		f(t)
 	}
 }

--- a/cmp/reporter.go
+++ b/cmp/reporter.go
@@ -385,8 +385,8 @@ func sortKeys(vs []reflect.Value) []reflect.Value {
 		return vs
 	}
 
-	// Sort the map keys
-	sort.Slice(vs, func(i, j int) bool { return isLess(vs[i], vs[j]) })
+	// Sort the map keys.
+	sort.Sort(valueSorter(vs))
 
 	// Deduplicate keys (fails for NaNs).
 	vs2 := vs[:1]
@@ -397,3 +397,10 @@ func sortKeys(vs []reflect.Value) []reflect.Value {
 	}
 	return vs2
 }
+
+// TODO: Use sort.Slice once Google AppEngine is on Go1.8 or above.
+type valueSorter []reflect.Value
+
+func (vs valueSorter) Len() int           { return len(vs) }
+func (vs valueSorter) Less(i, j int) bool { return isLess(vs[i], vs[j]) }
+func (vs valueSorter) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }


### PR DESCRIPTION
Avoid any features introduced in newer versions such as:
* testing.T.Run
* sort.Slice
* sort.SliceStable
* sort.IsSliceSorted

Fixes #2