### PR TITLE
Make lack of support for AllowUnexported more obvious

### DIFF
--- a/cmp/options.go
+++ b/cmp/options.go
@@ -262,6 +262,9 @@ type comparer struct {
 //
 // NOTE: This feature is experimental and may be removed!
 func AllowUnexported(types ...interface{}) Option {
+	if !supportAllowUnexported {
+		panic("AllowUnexported is not supported on App Engine Classic or GopherJS")
+	}
 	m := make(map[reflect.Type]bool)
 	for _, typ := range types {
 		t := reflect.TypeOf(typ)

--- a/cmp/unsafe_panic.go
+++ b/cmp/unsafe_panic.go
@@ -8,6 +8,8 @@ package cmp
 
 import "reflect"
 
+const supportAllowUnexported = false
+
 func unsafeRetrieveField(reflect.Value, reflect.StructField) reflect.Value {
-	panic("unsafeRetrieveField is not implemented on appengine or gopherjs")
+	panic("unsafeRetrieveField is not implemented")
 }

--- a/cmp/unsafe_reflect.go
+++ b/cmp/unsafe_reflect.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+const supportAllowUnexported = true
+
 // unsafeRetrieveField uses unsafe to forcibly retrieve any field from a struct
 // such that the value has read-write permissions.
 //


### PR DESCRIPTION
Rather than waiting until the unsafeRetrieveField helper
function is actually called, panic at the moment someone tries
to use AllowUnexported to make the failure more obvious.