### PR TITLE
Remove warning about status of AllowUnexported

### DIFF
--- a/cmp/options.go
+++ b/cmp/options.go
@@ -257,10 +257,10 @@ type comparer struct {
 // comparison) and most attempts to compare *regexp.Regexp types are interested
 // in only checking that the regular expression strings are equal.
 // Both of these are accomplished using Comparers:
+//
 //	Comparer(func(x, y reflect.Type) bool { return x == y })
 //	Comparer(func(x, y *regexp.Regexp) bool { return x.String() == y.String() })
 //
-// NOTE: This feature is experimental and may be removed!
 func AllowUnexported(types ...interface{}) Option {
 	if !supportAllowUnexported {
 		panic("AllowUnexported is not supported on App Engine Classic or GopherJS")


### PR DESCRIPTION
At this point, we will not be removing the AllowUnexported option
as there are several use-cases that legitimately benefit from it.
Also, the current documentation does a good job of explaining
what the proper use of it is. Thus, remove the warning as it is
unhelpful and confusing to users.

The other (unlikely) alternative I can see in the future is to
make AllowUnexported the default behavior for all comparisons
effectively making AllowUnexported a noop. That would be a
backwards compatible change.