### PR TITLE
Travis: Check for gofmt issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: go
 go:
-- 1.6
-- 1.x
+  - 1.x
+  - 1.6
+script:
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go test -v ./...


### PR DESCRIPTION
The default test script is `go test -v ./...` (assuming a Makefile is not present) according to Travis docs at https://docs.travis-ci.com/user/languages/go/#Default-Test-Script.

Add an additional gofmt check to help catch formatting issues in PRs. This is motivated by a previous occurrence at https://github.com/google/go-cmp/pull/9#discussion_r127624347.

Also swap the order of Go versions 1.x and 1.6. 1.x is higher priority, so it makes more sense to run it first and report issues right away. 1.6 is lower priority, so it's better to prioritize it lower.

Use 2 space indent in the .yml file, which is consistent with the formatting in Travis documentation and examples.

/cc @dsnet