### PR TITLE
Travis: Run go vet; use race detector during tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: go
 go:
   - 1.x
   - 1.6
+  - master
+matrix:
+  allow_failures:
+    - go: master
+  fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (it is intended for this package to have no dependencies other than the standard library).
 script:
-  - diff -u <(echo -n) <(gofmt -d .)
-  - go test -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ sudo: false
 language: go
 go:
   - 1.x
-  - 1.6
   - master
 matrix:
+  include:
+    - go: 1.6.x
+      script: go test -v -race ./...
   allow_failures:
     - go: master
   fast_finish: true

--- a/cmp/cmpopts/sort_go18.go
+++ b/cmp/cmpopts/sort_go18.go
@@ -15,8 +15,8 @@ const hasReflectStructOf = true
 
 func mapEntryType(t reflect.Type) reflect.Type {
 	return reflect.StructOf([]reflect.StructField{
-		reflect.StructField{Name: "K", Type: t.Key()},
-		reflect.StructField{Name: "V", Type: t.Elem()},
+		{Name: "K", Type: t.Key()},
+		{Name: "V", Type: t.Elem()},
 	})
 }
 

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -200,14 +200,14 @@ func TestOptions(t *testing.T) {
 	}, {
 		label: "SortMaps",
 		x: map[MyTime]string{
-			MyTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}: "0th birthday",
-			MyTime{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)}: "1st birthday",
-			MyTime{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC)}: "2nd birthday",
+			{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}: "0th birthday",
+			{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)}: "1st birthday",
+			{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC)}: "2nd birthday",
 		},
 		y: map[MyTime]string{
-			MyTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "0th birthday",
-			MyTime{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "1st birthday",
-			MyTime{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "2nd birthday",
+			{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "0th birthday",
+			{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "1st birthday",
+			{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "2nd birthday",
 		},
 		opts:      []cmp.Option{SortMaps(func(x, y time.Time) bool { return x.Before(y) })},
 		wantEqual: false,

--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -1478,18 +1478,18 @@ func project2Tests() []test {
 	createBatch := func() ts.GermBatch {
 		return ts.GermBatch{
 			DirtyGerms: map[int32][]*pb.Germ{
-				17: []*pb.Germ{
-					&pb.Germ{Stringer: pb.Stringer{"germ1"}},
+				17: {
+					{Stringer: pb.Stringer{"germ1"}},
 				},
-				18: []*pb.Germ{
-					&pb.Germ{Stringer: pb.Stringer{"germ2"}},
-					&pb.Germ{Stringer: pb.Stringer{"germ3"}},
-					&pb.Germ{Stringer: pb.Stringer{"germ4"}},
+				18: {
+					{Stringer: pb.Stringer{"germ2"}},
+					{Stringer: pb.Stringer{"germ3"}},
+					{Stringer: pb.Stringer{"germ4"}},
 				},
 			},
 			GermMap: map[int32]*pb.Germ{
-				13: &pb.Germ{Stringer: pb.Stringer{"germ13"}},
-				21: &pb.Germ{Stringer: pb.Stringer{"germ21"}},
+				13: {Stringer: pb.Stringer{"germ13"}},
+				21: {Stringer: pb.Stringer{"germ21"}},
 			},
 			DishMap: map[int32]*ts.Dish{
 				0: ts.CreateDish(nil, io.EOF),
@@ -1602,8 +1602,8 @@ func project3Tests() []test {
 		d.Discord = 554
 		d.Proto = pb.Dirt{Stringer: pb.Stringer{"proto"}}
 		d.SetWizard(map[string]*pb.Wizard{
-			"harry": &pb.Wizard{Stringer: pb.Stringer{"potter"}},
-			"albus": &pb.Wizard{Stringer: pb.Stringer{"dumbledore"}},
+			"harry": {Stringer: pb.Stringer{"potter"}},
+			"albus": {Stringer: pb.Stringer{"dumbledore"}},
 		})
 		d.SetLastTime(54321)
 		return d
@@ -1637,7 +1637,7 @@ func project3Tests() []test {
 			d := createDirt()
 			d.Discord = 500
 			d.SetWizard(map[string]*pb.Wizard{
-				"harry": &pb.Wizard{Stringer: pb.Stringer{"otter"}},
+				"harry": {Stringer: pb.Stringer{"otter"}},
 			})
 			return d
 		}(),


### PR DESCRIPTION
This change augments the Travis CI build to perform:

-	Include `-s` (simplify) flag when checking that all files follow `gofmt` style.
-	Check that `go vet` does not report any problems.
-	Use race detector when running tests, to help catch data races.
-	Include a fast-finish allowed failure build on `master` (tip). Due to a chance of false positives, failures on tip are not critical, but manually looking over them can help spot issues either in this project, or in the tip version of Go.

Resolves #13. /cc @dsnet