### PR TITLE
Use an Options group instead of copying-append

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -96,7 +96,7 @@ func Equal(x, y interface{}, opts ...Option) bool {
 // Do not depend on this output being stable.
 func Diff(x, y interface{}, opts ...Option) string {
 	r := new(defaultReporter)
-	opts = append(opts[:len(opts):len(opts)], r) // Force copy when appending
+	opts = Options{Options(opts), r}
 	eq := Equal(x, y, opts...)
 	d := r.String()
 	if (d == "") != eq {


### PR DESCRIPTION
A copying-append runs in O(n) where n is the number of options.
Instead, just create a new Options group, which is O(1).

Also switch the tests to run in parallel to increase chances of
detecting races.