### PR TITLE
Add implicit filter to Transformers

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -1633,15 +1633,11 @@ func (gs germSorter) Swap(i, j int)      { gs[i], gs[j] = gs[j], gs[i] }
 func project2Tests() []test {
 	const label = "Project2"
 
-	sortGerms := cmp.FilterValues(func(x, y []*pb.Germ) bool {
-		ok1 := sort.IsSorted(germSorter(x))
-		ok2 := sort.IsSorted(germSorter(y))
-		return !ok1 || !ok2
-	}, cmp.Transformer("Sort", func(in []*pb.Germ) []*pb.Germ {
+	sortGerms := cmp.Transformer("Sort", func(in []*pb.Germ) []*pb.Germ {
 		out := append([]*pb.Germ(nil), in...) // Make copy
 		sort.Sort(germSorter(out))
 		return out
-	}))
+	})
 
 	equalDish := cmp.Comparer(func(x, y *ts.Dish) bool {
 		if x == nil || y == nil {
@@ -1739,7 +1735,7 @@ func project2Tests() []test {
 {teststructs.GermBatch}.DirtyGerms[17]:
 	-: <non-existent>
 	+: []*testprotos.Germ{s"germ1"}
-{teststructs.GermBatch}.DirtyGerms[18][2->?]:
+Sort({teststructs.GermBatch}.DirtyGerms[18])[2->?]:
 	-: s"germ4"
 	+: <non-existent>
 {teststructs.GermBatch}.DishMap[1]:

--- a/cmp/example_test.go
+++ b/cmp/example_test.go
@@ -258,16 +258,11 @@ func ExampleOption_equalEmpty() {
 // This example is for demonstrative purposes; use cmpopts.SortSlices instead.
 func ExampleOption_sortedSlice() {
 	// This Transformer sorts a []int.
-	// Since the transformer transforms []int into []int, there is problem where
-	// this is recursively applied forever. To prevent this, use a FilterValues
-	// to first check for the condition upon which the transformer ought to apply.
-	trans := cmp.FilterValues(func(x, y []int) bool {
-		return !sort.IntsAreSorted(x) || !sort.IntsAreSorted(y)
-	}, cmp.Transformer("Sort", func(in []int) []int {
+	trans := cmp.Transformer("Sort", func(in []int) []int {
 		out := append([]int(nil), in...) // Copy input to avoid mutating it
 		sort.Ints(out)
 		return out
-	}))
+	})
 
 	x := struct{ Ints []int }{[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}
 	y := struct{ Ints []int }{[]int{2, 8, 0, 9, 6, 1, 4, 7, 3, 5}}


### PR DESCRIPTION
Declaring a transformer "func(T) T" where T is a concrete type
is a common transformation. However, this is currently problematic
as the transformation now infinitely applies to itself recursively.

In order to allow this form of transformation, add a simple
(but subtle) filter to Transformers where a Transformer can only
apply if that specific Transformer does not already exist within
the tail of the current Path since the last non-Transform step.

This rule does not prevent more advance usages of Transformers
where the user *does* want the Transformer to apply recursively
to previously transformed output, since those situations are
almost always followed by some path step that is *not* a
transformation (e.g., pointer indirect, slice indexing, etc).

Fixes #17
Fixes #51