### PR TITLE
Fix Bug With Nil Stringers

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -79,6 +79,7 @@ func TestDiff(t *testing.T) {
 	tests = append(tests, transformerTests()...)
 	tests = append(tests, embeddedTests()...)
 	tests = append(tests, methodTests()...)
+	tests = append(tests, formatTests()...)
 	tests = append(tests, project1Tests()...)
 	tests = append(tests, project2Tests()...)
 	tests = append(tests, project3Tests()...)
@@ -1359,6 +1360,21 @@ func methodTests() []test {
 		x:     ts.AssignD(make(chan bool)),
 		y:     ts.AssignD(make(chan bool)),
 	}}
+}
+
+func formatTests() []test {
+	const label = "Format/"
+	return []test{
+		{
+			label: label + "NilStringer",
+			x:     new(fmt.Stringer),
+			y:     nil,
+			wantDiff: `
+:
+	-: &<nil>
+	+: <non-existent>`,
+		},
+	}
 }
 
 func project1Tests() []test {

--- a/cmp/internal/value/format.go
+++ b/cmp/internal/value/format.go
@@ -44,7 +44,7 @@ func formatAny(v reflect.Value, conf formatConfig, visited map[uintptr]bool) str
 		return "<non-existent>"
 	}
 	if conf.useStringer && v.Type().Implements(stringerIface) {
-		if v.Kind() == reflect.Ptr && v.IsNil() {
+		if (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) && v.IsNil() {
 			return "<nil>"
 		}
 		return fmt.Sprintf("%q", v.Interface().(fmt.Stringer).String())


### PR DESCRIPTION
There was a bug in the way this package handles nil Stringer values.  This diff fixes the bug, and adds a previously failing test.