### PR TITLE
Fix panic in sort.go

### DIFF
--- a/cmp/internal/value/sort.go
+++ b/cmp/internal/value/sort.go
@@ -24,7 +24,7 @@ func SortKeys(vs []reflect.Value) []reflect.Value {
 	// Deduplicate keys (fails for NaNs).
 	vs2 := vs[:1]
 	for _, v := range vs[1:] {
-		if v.Interface() != vs2[len(vs2)-1].Interface() {
+		if isLess(vs2[len(vs2)-1], v) {
 			vs2 = append(vs2, v)
 		}
 	}

--- a/cmp/internal/value/sort_test.go
+++ b/cmp/internal/value/sort_test.go
@@ -132,15 +132,22 @@ func TestSortKeys(t *testing.T) {
 			complex(math.NaN(), math.NaN()): true,
 		},
 		want: []interface{}{
-			math.NaN(), math.NaN(), math.NaN(), math.NaN(),
-			complex(math.NaN(), math.NaN()), complex(math.NaN(), math.NaN()),
-			complex(math.NaN(), 0), complex(math.NaN(), 0), complex(math.NaN(), 0), complex(math.NaN(), 0),
-			complex(0, math.NaN()), complex(0, math.NaN()), complex(0, math.NaN()), complex(0, math.NaN()),
+			math.NaN(),
+			complex(math.NaN(), math.NaN()),
+			complex(math.NaN(), 0),
+			complex(0, math.NaN()),
 		},
 	}}
 
 	for i, tt := range tests {
-		keys := append(reflect.ValueOf(tt.in).MapKeys(), reflect.ValueOf(tt.in).MapKeys()...)
+		// Intentionally pass the map via an unexported field to detect panics.
+		// Unfortunately, we cannot actually test the keys without using unsafe.
+		v := reflect.ValueOf(struct{ x map[interface{}]bool }{tt.in}).Field(0)
+		value.SortKeys(append(v.MapKeys(), v.MapKeys()...))
+
+		// Try again, with keys that have read-write access in reflect.
+		v = reflect.ValueOf(tt.in)
+		keys := append(v.MapKeys(), v.MapKeys()...)
 		var got []interface{}
 		for _, k := range value.SortKeys(keys) {
 			got = append(got, k.Interface())


### PR DESCRIPTION
Avoid using reflect.Value.Interface to de-duplicate keys since
some keys may have source from an unexported field,
causing the logic to panic. Instead, just rely on the isLess function,
which is already safe to use on unexported values.

Fixes #38