### PR TITLE
Allow use of AllowUnexported on GopherJS

### DIFF
--- a/cmp/options.go
+++ b/cmp/options.go
@@ -348,7 +348,7 @@ func (cm comparer) String() string {
 // all unexported fields on specified struct types.
 func AllowUnexported(types ...interface{}) Option {
 	if !supportAllowUnexported {
-		panic("AllowUnexported is not supported on App Engine Classic or GopherJS")
+		panic("AllowUnexported is not supported on App Engine Classic")
 	}
 	m := make(map[reflect.Type]bool)
 	for _, typ := range types {

--- a/cmp/unsafe_panic.go
+++ b/cmp/unsafe_panic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build appengine js
+// +build appengine
 
 package cmp
 

--- a/cmp/unsafe_reflect.go
+++ b/cmp/unsafe_reflect.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build !appengine,!js
+// +build !appengine
 
 package cmp
 


### PR DESCRIPTION
GopherJS does not have a complete implementation of unsafe, but it is
complete enough that it can do basic pointer arithmetic,
which is all we need to forcibly export an unexported field.