### PR TITLE
Use raw literal for string formatting

### DIFF
--- a/cmp/internal/value/format_test.go
+++ b/cmp/internal/value/format_test.go
@@ -47,7 +47,7 @@ func TestFormat(t *testing.T) {
 		want: "map[value.key]string{{a: 5, b: \"key\", c: (chan bool)(0x00)}: \"hello\"}",
 	}, {
 		in:   map[io.Reader]string{new(bytes.Reader): "hello"},
-		want: "map[io.Reader]string{0x00: \"hello\"}",
+		want: "map[io.Reader]string{(*bytes.Reader)(0x00): \"hello\"}",
 	}, {
 		in: func() interface{} {
 			var a = []interface{}{nil}


### PR DESCRIPTION
When formatting strings, avoid using strconv.Quote if the string looks
like it has already been escaped. Instead, use a raw string literal
by wrapping the string with '`' characters if possible.
For now, we still use strconv.Quote if the input string contains newlines
to maintain the property that Format outputs a single line.

Also, prefix strings obtained by the Stringer.String method with a 's'.
This allows users to more easily distinguish when an output really is
of type string or if the String method was used.