### PR TITLE
Fix reporter difference count

### DIFF
--- a/cmp/reporter.go
+++ b/cmp/reporter.go
@@ -49,5 +49,5 @@ func (r *defaultReporter) String() string {
 	if r.ndiffs == len(r.diffs) {
 		return s
 	}
-	return fmt.Sprintf("%s... %d more differences ...", s, len(r.diffs)-r.ndiffs)
+	return fmt.Sprintf("%s... %d more differences ...", s, r.ndiffs-len(r.diffs))
 }


### PR DESCRIPTION
The defaultReporter.ndiffs field holds the total number of differences,
while the diffs fields holds a truncated list of differences.
The subtraction math is backwards, resulting in a negative count.