### PR TITLE
Explicitly convert assignable nil interface values

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -84,6 +84,13 @@ func TestDiff(t *testing.T) {
 func comparerTests() []test {
 	const label = "Comparer"
 
+	type Iface1 interface {
+		Method()
+	}
+	type Iface2 interface {
+		Method()
+	}
+
 	type tarHeader struct {
 		Name       string
 		Mode       int64
@@ -419,6 +426,33 @@ root:
 		label:    label,
 		x:        []*pb.Stringer{{`multi\nline\nline\nline`}},
 		wantDiff: ":\n\t-: []*testprotos.Stringer{s`multi\\nline\\nline\\nline`}\n\t+: <non-existent>",
+	}, {
+		label: label,
+		x:     struct{ I Iface2 }{},
+		y:     struct{ I Iface2 }{},
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y Iface1) bool {
+				return x == nil && y == nil
+			}),
+		},
+	}, {
+		label: label,
+		x:     struct{ I Iface2 }{},
+		y:     struct{ I Iface2 }{},
+		opts: []cmp.Option{
+			cmp.Transformer("", func(v Iface1) bool {
+				return v == nil
+			}),
+		},
+	}, {
+		label: label,
+		x:     struct{ I Iface2 }{},
+		y:     struct{ I Iface2 }{},
+		opts: []cmp.Option{
+			cmp.FilterValues(func(x, y Iface1) bool {
+				return x == nil && y == nil
+			}, cmp.Ignore()),
+		},
 	}}
 }
 


### PR DESCRIPTION
The reflect package has a bug (golang/go#22143).
Let R and T both be interface types and R be assignable to T.
Let F be a function that takes T as its argument.

The Go language lets you directly call F with a nil T or a nil R
(since R is assignable to T) without any special handling.

Currently, reflect allows you to call F with a nil T,
but panics when calling F with a nil R. To avoid this panic,
we explicitly check for the condition where a value:
	* is an interface type
	* is nil
	* is not exactly same as type T
and re-create the value as a nil interface of type T.