### PR TITLE
Remove useless return value from applicableOption.apply

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -304,7 +304,8 @@ func (s *state) tryOptions(vx, vy reflect.Value, t reflect.Type) bool {
 
 	// Evaluate all filters and apply the remaining options.
 	if opt := opts.filter(s, vx, vy, t); opt != nil {
-		return opt.apply(s, vx, vy)
+		opt.apply(s, vx, vy)
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
For all implementations of apply, it either returns true or panics.
Thus, the bool return value is a useless piece of information.