### PR TITLE
Add Transform.Option helper method

### DIFF
--- a/cmp/path.go
+++ b/cmp/path.go
@@ -79,6 +79,11 @@ type (
 		PathStep
 		Name() string
 		Func() reflect.Value
+
+		// Option returns the originally constructed Transformer option.
+		// The == operator can be used to detect the exact option used.
+		Option() Option
+
 		isTransform()
 	}
 )
@@ -260,6 +265,7 @@ func (sf structField) Name() string         { return sf.name }
 func (sf structField) Index() int           { return sf.idx }
 func (tf transform) Name() string           { return tf.trans.name }
 func (tf transform) Func() reflect.Value    { return tf.trans.fnc }
+func (tf transform) Option() Option         { return tf.trans }
 
 func (pathStep) isPathStep()           {}
 func (sliceIndex) isSliceIndex()       {}


### PR DESCRIPTION
Currently there is no easy way to create non-reentrant transformers
where they do not recursively apply on their own output.
You could check for the Transformer name, but the API does not
require the names to be unique.

The only way to write a helper to do this is to generate some obscure
name that is guaranteed to probabilistic never have a conflict.

A better approach is to simply return the original Option
as returned by the Transformer constructor.
Thus, users can rely on == to check if a Transform step exactly
matches a Transformer that they created.

It would be useful to a non-reentrant transformer to cmpopts,
but that can be a future addition. It will also need a better name.