### PR TITLE
Report with primitive types in diffs

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -453,6 +453,17 @@ root:
 				return x == nil && y == nil
 			}, cmp.Ignore()),
 		},
+	}, {
+		label: label,
+		x:     []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63, "name": "Sammy Sosa"}},
+		y:     []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65.0, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63.0, "name": "Sammy Sosa"}},
+		wantDiff: `
+root[0]["hr"]:
+	-: int(65)
+	+: float64(65)
+root[1]["hr"]:
+	-: int(63)
+	+: float64(63)`,
 	}}
 }
 

--- a/cmp/internal/value/format_test.go
+++ b/cmp/internal/value/format_test.go
@@ -85,7 +85,7 @@ func TestFormat(t *testing.T) {
 		// ensure the format logic does not depend on read-write access
 		// to the reflect.Value.
 		v := reflect.ValueOf(struct{ x interface{} }{tt.in}).Field(0)
-		got := formatAny(v, formatConfig{useStringer: true, printType: true, followPointers: true}, nil)
+		got := formatAny(v, FormatConfig{UseStringer: true, printType: true, followPointers: true}, nil)
 		if got != tt.want {
 			t.Errorf("test %d, Format():\ngot  %q\nwant %q", i, got, tt.want)
 		}

--- a/cmp/reporter.go
+++ b/cmp/reporter.go
@@ -30,12 +30,12 @@ func (r *defaultReporter) Report(x, y reflect.Value, eq bool, p Path) {
 	const maxLines = 256
 	r.ndiffs++
 	if r.nbytes < maxBytes && r.nlines < maxLines {
-		sx := value.Format(x, true)
-		sy := value.Format(y, true)
+		sx := value.Format(x, value.FormatConfig{UseStringer: true})
+		sy := value.Format(y, value.FormatConfig{UseStringer: true})
 		if sx == sy {
-			// Stringer is not helpful, so rely on more exact formatting.
-			sx = value.Format(x, false)
-			sy = value.Format(y, false)
+			// Unhelpful output, so use more exact formatting.
+			sx = value.Format(x, value.FormatConfig{PrintPrimitiveType: true})
+			sy = value.Format(y, value.FormatConfig{PrintPrimitiveType: true})
 		}
 		s := fmt.Sprintf("%#v:\n\t-: %s\n\t+: %s\n", p, sx, sy)
 		r.diffs = append(r.diffs, s)


### PR DESCRIPTION
When the formatted strings are identical, the reporter tries to fallback
on more exact formatting. This fallback should include the types for
primitive types since the difference can simply be between
an int and an uint.

Fixes #64