### PR TITLE
Support purego build tag

### DIFF
--- a/cmp/options.go
+++ b/cmp/options.go
@@ -355,7 +355,7 @@ func (cm comparer) String() string {
 // all unexported fields on specified struct types.
 func AllowUnexported(types ...interface{}) Option {
 	if !supportAllowUnexported {
-		panic("AllowUnexported is not supported on App Engine Classic or GopherJS")
+		panic("AllowUnexported is not supported on purego builds, Google App Engine Standard, or GopherJS")
 	}
 	m := make(map[reflect.Type]bool)
 	for _, typ := range types {

--- a/cmp/unsafe_panic.go
+++ b/cmp/unsafe_panic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build appengine js
+// +build purego appengine js
 
 package cmp
 

--- a/cmp/unsafe_reflect.go
+++ b/cmp/unsafe_reflect.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build !appengine,!js
+// +build !purego,!appengine,!js
 
 package cmp
 


### PR DESCRIPTION
The proposal in golang/go#23172 was accepted. The "purego" build tag
is intended to be a community agreed upon soft-signal to indicate the
forbidden use of unsafe, assembly, or cgo.

A change in the future will remove special-casing the appengine and js tags
once the related toolchains support purego (possibly after some bake-in period).