### PR TITLE
Add DetectCycles to detect cycles in compared structs

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -119,6 +119,10 @@ type state struct {
 	// These fields, once set by processOption, will not change.
 	exporters map[reflect.Type]bool // Set of structs with unexported field visibility
 	opts      Options               // List of all fundamental and filter options
+
+	// detectCycles is set by the DetectCycles option, and it indicates to
+	// enable the cycles check when a pointer is compared.
+	detectCycles bool
 }
 
 func newState(opts []Option) *state {
@@ -156,6 +160,8 @@ func (s *state) processOption(opt Option) {
 			panic("difference reporter already registered")
 		}
 		s.reporter = opt
+	case detectCycles:
+		s.detectCycles = true
 	default:
 		panic(fmt.Sprintf("unknown option %T", opt))
 	}
@@ -180,8 +186,6 @@ func (s *state) statelessCompare(vx, vy reflect.Value) diff.Result {
 }
 
 func (s *state) compareAny(vx, vy reflect.Value) {
-	// TODO: Support cyclic data structures.
-
 	// Rule 0: Differing types are never equal.
 	if !vx.IsValid() || !vy.IsValid() {
 		s.report(vx.IsValid() == vy.IsValid(), vx, vy)
@@ -239,8 +243,21 @@ func (s *state) compareAny(vx, vy reflect.Value) {
 			s.report(vx.IsNil() && vy.IsNil(), vx, vy)
 			return
 		}
-		s.curPath.push(&indirect{pathStep{t.Elem()}})
+		s.curPath.push(&indirect{
+			pathStep: pathStep{t.Elem()},
+			xAddr:    vx.Elem().UnsafeAddr(),
+			yAddr:    vy.Elem().UnsafeAddr(),
+		})
 		defer s.curPath.pop()
+
+		// If detectCycles is enabled, look in the path stack and search for
+		// pointer cycle. If one is find, compare the cycles.
+		if s.detectCycles {
+			if cyclesEqual, ok := compareCycles(s.curPath); ok {
+				s.report(cyclesEqual, vx, vy)
+				return
+			}
+		}
 		s.compareAny(vx.Elem(), vy.Elem())
 		return
 	case reflect.Interface:
@@ -551,4 +568,54 @@ func makeAddressable(v reflect.Value) reflect.Value {
 	vc := reflect.New(v.Type()).Elem()
 	vc.Set(v)
 	return vc
+}
+
+// compareCycles calculates the cyclic pointer chain length by going
+// over the path stack.
+// It calculates both a cyclic chain of x values and for y values, and
+// compare them.
+// It returns:
+//      equals if detected cycles are equal.
+//      ok as true if cycles were detected.
+func compareCycles(p Path) (equals bool, ok bool) {
+	if len(p) == 0 {
+		return false, false
+	}
+
+	// Check the current path step for the address values.
+	// If it is not a cycleStep, there is no point to check the
+	// chains lengths
+	curStep, ok := p[len(p)-1].(*indirect)
+	if !ok || (curStep.xAddr == 0 && curStep.yAddr == 0) {
+		return false, false
+	}
+
+	// Find the next occurrence in the chain path of either xAddr or yAddr
+	// of the curStep.
+	var xLen, yLen, length int
+	for i := len(p) - 2; i > 0; i-- {
+		cs, ok := p[i].(*indirect)
+		if !ok || (curStep.xAddr == 0 && curStep.yAddr == 0) {
+			continue
+		}
+
+		// since this step is a pointer step, increase the chain length
+		length += 1
+
+		// Check for the same address. We want to return the smallest cycle,
+		// so we update only if the current length value is 0
+		if xLen == 0 && cs.xAddr == curStep.xAddr {
+			xLen = length
+		}
+		if yLen == 0 && cs.yAddr == curStep.yAddr {
+			yLen = length
+		}
+
+		// If we found lengths for both x and y, we can return, there is no
+		// need to go over the whole stack.
+		if xLen != 0 && yLen != 0 {
+			break
+		}
+	}
+	return xLen == yLen, yLen != 0 && xLen != 0
 }

--- a/cmp/options.go
+++ b/cmp/options.go
@@ -451,3 +451,17 @@ func getFuncName(p uintptr) string {
 	}
 	return name
 }
+
+// DetectCycles is an option that prevents infinite searching in cyclic data structure.
+// It iterates the whole path stack every time a pointer is tested to check for
+// cycles thus it reduces the runtime performance.
+// It finds cycles by adding information to the path stack any time a pointer is tested.
+func DetectCycles() Option { return detectCycles{} }
+
+type detectCycles struct{}
+
+func (c detectCycles) filter(s *state, vx, vy reflect.Value, t reflect.Type) applicableOption {
+	return nil
+}
+
+func (c detectCycles) String() string { return "DetectCycles()" }

--- a/cmp/path.go
+++ b/cmp/path.go
@@ -213,6 +213,9 @@ type (
 	}
 	indirect struct {
 		pathStep
+		// xAddr and yAddr are set if the kind of the current step is Ptr.
+		// They contain the addresses pointing by vx an vy.
+		xAddr, yAddr uintptr
 	}
 	transform struct {
 		pathStep


### PR DESCRIPTION
The current comparison fails on stack overflow when given a cyclic struct
(such as a cyclic linked list for example).

This fix adds a new option: DecetctCycles, which finds cycles by adding information
to the path stack, when iterating over pointers.

When a cycle is checked (every time a pointer kind is compared) the path stack
is iterated to find cycles. The comparison of cycles is by they length.

Fixes: #74