### PR TITLE
Add pointer comparison in compareAny

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -239,6 +239,13 @@ func (s *state) compareAny(vx, vy reflect.Value) {
 			s.report(vx.IsNil() && vy.IsNil(), vx, vy)
 			return
 		}
+
+		// If pointers are pointing on the same thing, we can report them as equal
+		if vx.Pointer() == vy.Pointer() {
+			s.report(true, vx, vy)
+			return
+		}
+
 		s.curPath.push(&indirect{pathStep{t.Elem()}})
 		defer s.curPath.pop()
 		s.compareAny(vx.Elem(), vy.Elem())

--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -464,6 +464,10 @@ root[0]["hr"]:
 root[1]["hr"]:
 	-: int(63)
 	+: float64(63)`,
+	}, {
+		label: label + "/types",
+		x:     reflect.TypeOf(1),
+		y:     reflect.TypeOf(2),
 	}}
 }
 


### PR DESCRIPTION
When comparing pointers in compareAny, if the pointers are pointing on the
same object we report that they are equal.

Fixes #80