### PR TITLE
Enforce tests to provide a reason

### DIFF
--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -731,6 +731,8 @@ func TestOptions(t *testing.T) {
 				gotEqual = cmp.Equal(tt.x, tt.y, tt.opts...)
 			}()
 			switch {
+			case tt.reason == "":
+				t.Errorf("reason must be provided")
 			case gotPanic == "" && tt.wantPanic:
 				t.Errorf("expected Equal panic\nreason: %s", tt.reason)
 			case gotPanic != "" && !tt.wantPanic:
@@ -972,6 +974,8 @@ func TestPanic(t *testing.T) {
 			}()
 
 			switch {
+			case tt.reason == "":
+				t.Errorf("reason must be provided")
 			case tt.wantPanic == "" && gotPanic != "":
 				t.Errorf("unexpected panic message: %s\nreason: %s", gotPanic, tt.reason)
 			case tt.wantPanic != "" && !strings.Contains(gotPanic, tt.wantPanic):


### PR DESCRIPTION
To prevent future developers from getting lazy,
check that a reason is given as part of each test case.

Checks are only given for cmpopts.
The cmp tests lack reasons, which is future work.