### PR TITLE
Fix cycle detection in internal/value.Format

### DIFF
--- a/cmp/internal/value/format_test.go
+++ b/cmp/internal/value/format_test.go
@@ -54,7 +54,7 @@ func TestFormat(t *testing.T) {
 			a[0] = a
 			return a
 		}(),
-		want: "[]interface {}{([]interface {})(0x00)}",
+		want: "[]interface {}{[]interface {}{*(*interface {})(0x00)}}",
 	}, {
 		in: func() interface{} {
 			type A *A
@@ -85,7 +85,7 @@ func TestFormat(t *testing.T) {
 		// ensure the format logic does not depend on read-write access
 		// to the reflect.Value.
 		v := reflect.ValueOf(struct{ x interface{} }{tt.in}).Field(0)
-		got := formatAny(v, FormatConfig{UseStringer: true, printType: true, followPointers: true}, nil)
+		got := formatAny(v, FormatConfig{UseStringer: true, printType: true, followPointers: true}, visited{})
 		if got != tt.want {
 			t.Errorf("test %d, Format():\ngot  %q\nwant %q", i, got, tt.want)
 		}

--- a/cmp/internal/value/pointer_purego.go
+++ b/cmp/internal/value/pointer_purego.go
@@ -1,0 +1,23 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build purego
+
+package value
+
+import "reflect"
+
+// Pointer is an opaque typed pointer and is guaranteed to be comparable.
+type Pointer struct {
+	p uintptr
+	t reflect.Type
+}
+
+// PointerOf returns a Pointer from v, which must be a
+// reflect.Ptr, reflect.Slice, or reflect.Map.
+func PointerOf(v reflect.Value) Pointer {
+	// NOTE: Storing a pointer as an uintptr is technically incorrect as it
+	// assumes that the GC implementation does not use a moving collector.
+	return Pointer{v.Pointer(), v.Type()}
+}

--- a/cmp/internal/value/pointer_unsafe.go
+++ b/cmp/internal/value/pointer_unsafe.go
@@ -1,0 +1,26 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build !purego
+
+package value
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Pointer is an opaque typed pointer and is guaranteed to be comparable.
+type Pointer struct {
+	p unsafe.Pointer
+	t reflect.Type
+}
+
+// PointerOf returns a Pointer from v, which must be a
+// reflect.Ptr, reflect.Slice, or reflect.Map.
+func PointerOf(v reflect.Value) Pointer {
+	// The proper representation of a pointer is unsafe.Pointer,
+	// which is necessary if the GC ever uses a moving collector.
+	return Pointer{unsafe.Pointer(v.Pointer()), v.Type()}
+}


### PR DESCRIPTION
The cycle detection in value.Format uses a map of uintptrs, which is not
correct as this assumes that the Go GC never uses a moving collector.
Instead, we should be using unsafe.Pointer, which the GC knows how to scan.

Also, push pointer checking of slices down to the level of individual elements.
We do this because the slice pointer is not sufficient to determine equality.
For example, v[:0] and v[:1] both have the same slice pointer, but are
clearly different values.

Since the purego environment forbids the use of unsafe, create a Pointer type
that is an abstraction over an opaque pointer. The Pointer type can only be
compared. In the purego, continue to use uintptr, which is the best we can do.