### PR TITLE
go.mod: add module file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/go-cmp


### PR DESCRIPTION
Go 1.11 is now released with preliminary support for Go modules.
If a repository is checked outside of the GOPATH, then the Go toolchain will
use the module support by default. However, it requires a go.mod file so that
the toolchain can derive the import paths of all packages living under the
tree containing the go.mod file.