### PR TITLE
Slynickel/options

### DIFF
--- a/cmp/cmpopts/equate.go
+++ b/cmp/cmpopts/equate.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 func equateAlways(_, _ interface{}) bool { return true }

--- a/cmp/cmpopts/ignore.go
+++ b/cmp/cmpopts/ignore.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 // IgnoreFields returns an Option that ignores exported fields of the

--- a/cmp/cmpopts/sort.go
+++ b/cmp/cmpopts/sort.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/internal/function"
+	"go-cmp/cmp"
+	"go-cmp/cmp/internal/function"
 )
 
 // SortSlices returns a Transformer option that sorts all []V.

--- a/cmp/cmpopts/struct_filter.go
+++ b/cmp/cmpopts/struct_filter.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 // filterField returns a new Option where opt is only evaluated on paths that

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 type (

--- a/cmp/cmpopts/xform.go
+++ b/cmp/cmpopts/xform.go
@@ -5,7 +5,7 @@
 package cmpopts
 
 import (
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 type xformFilter struct{ xform cmp.Option }

--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -31,9 +31,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-cmp/cmp/internal/diff"
-	"github.com/google/go-cmp/cmp/internal/function"
-	"github.com/google/go-cmp/cmp/internal/value"
+	"go-cmp/cmp/internal/diff"
+	"go-cmp/cmp/internal/function"
+	"go-cmp/cmp/internal/value"
 )
 
 // BUG(dsnet): Maps with keys containing NaN values cannot be properly compared due to

--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	pb "github.com/google/go-cmp/cmp/internal/testprotos"
-	ts "github.com/google/go-cmp/cmp/internal/teststructs"
+	"go-cmp/cmp"
+	"go-cmp/cmp/cmpopts"
+	pb "go-cmp/cmp/internal/testprotos"
+	ts "go-cmp/cmp/internal/teststructs"
 )
 
 var now = time.Now()

--- a/cmp/example_test.go
+++ b/cmp/example_test.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
+	"go-cmp/cmp"
 )
 
 // TODO: Re-write these examples in terms of how you actually use the

--- a/cmp/internal/teststructs/project1.go
+++ b/cmp/internal/teststructs/project1.go
@@ -7,7 +7,7 @@ package teststructs
 import (
 	"time"
 
-	pb "github.com/google/go-cmp/cmp/internal/testprotos"
+	pb "go-cmp/cmp/internal/testprotos"
 )
 
 // This is an sanitized example of equality from a real use-case.

--- a/cmp/internal/teststructs/project2.go
+++ b/cmp/internal/teststructs/project2.go
@@ -7,7 +7,7 @@ package teststructs
 import (
 	"time"
 
-	pb "github.com/google/go-cmp/cmp/internal/testprotos"
+	pb "go-cmp/cmp/internal/testprotos"
 )
 
 // This is an sanitized example of equality from a real use-case.

--- a/cmp/internal/teststructs/project3.go
+++ b/cmp/internal/teststructs/project3.go
@@ -7,7 +7,7 @@ package teststructs
 import (
 	"sync"
 
-	pb "github.com/google/go-cmp/cmp/internal/testprotos"
+	pb "go-cmp/cmp/internal/testprotos"
 )
 
 // This is an sanitized example of equality from a real use-case.

--- a/cmp/internal/teststructs/project4.go
+++ b/cmp/internal/teststructs/project4.go
@@ -7,7 +7,7 @@ package teststructs
 import (
 	"time"
 
-	pb "github.com/google/go-cmp/cmp/internal/testprotos"
+	pb "go-cmp/cmp/internal/testprotos"
 )
 
 // This is an sanitized example of equality from a real use-case.

--- a/cmp/internal/value/sort_test.go
+++ b/cmp/internal/value/sort_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/internal/value"
+	"go-cmp/cmp"
+	"go-cmp/cmp/internal/value"
 )
 
 func TestSortKeys(t *testing.T) {

--- a/cmp/options.go
+++ b/cmp/options.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/google/go-cmp/cmp/internal/function"
+	"go-cmp/cmp/internal/function"
 )
 
 // Option configures for specific behavior of Equal and Diff. In particular,

--- a/cmp/options_test.go
+++ b/cmp/options_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	ts "github.com/google/go-cmp/cmp/internal/teststructs"
+	ts "go-cmp/cmp/internal/teststructs"
 )
 
 // Test that the creation of Option values with non-sensible inputs produces

--- a/cmp/reporter.go
+++ b/cmp/reporter.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-cmp/cmp/internal/value"
+	"go-cmp/cmp/internal/value"
 )
 
 type defaultReporter struct {

--- a/cmp/reporter.go
+++ b/cmp/reporter.go
@@ -26,28 +26,21 @@ func (r *defaultReporter) Report(x, y reflect.Value, eq bool, p Path) {
 	if eq {
 		return // Ignore equal results
 	}
-	const maxBytes = 4096
-	const maxLines = 256
-	r.ndiffs++
-	if r.nbytes < maxBytes && r.nlines < maxLines {
-		sx := value.Format(x, value.FormatConfig{UseStringer: true})
-		sy := value.Format(y, value.FormatConfig{UseStringer: true})
-		if sx == sy {
-			// Unhelpful output, so use more exact formatting.
-			sx = value.Format(x, value.FormatConfig{PrintPrimitiveType: true})
-			sy = value.Format(y, value.FormatConfig{PrintPrimitiveType: true})
-		}
-		s := fmt.Sprintf("%#v:\n\t-: %s\n\t+: %s\n", p, sx, sy)
-		r.diffs = append(r.diffs, s)
-		r.nbytes += len(s)
-		r.nlines += strings.Count(s, "\n")
+	sx := value.Format(x, value.FormatConfig{UseStringer: true})
+	sy := value.Format(y, value.FormatConfig{UseStringer: true})
+	if sx == sy {
+		// Unhelpful output, so use more exact formatting.
+		sx = value.Format(x, value.FormatConfig{PrintPrimitiveType: true})
+		sy = value.Format(y, value.FormatConfig{PrintPrimitiveType: true})
 	}
+	// Tab delimted output in the format of: Key,Value x,Value X,
+	s := fmt.Sprintf("%#v\t%s\t%s\t\n", p, sx, sy)
+	r.diffs = append(r.diffs, s)
+	r.nbytes += len(s)
+	r.nlines += strings.Count(s, "\n")
 }
 
 func (r *defaultReporter) String() string {
 	s := strings.Join(r.diffs, "")
-	if r.ndiffs == len(r.diffs) {
-		return s
-	}
-	return fmt.Sprintf("%s... %d more differences ...", s, r.ndiffs-len(r.diffs))
+	return s
 }


### PR DESCRIPTION
* Tab delimit the output of diff (breaks all tests)
* Stop using the module syntax, instead directly reference the internal packages
