### PR TITLE
add a DeepAllowUnexported cmpopt

### DIFF
--- a/cmp/cmpopts/deep_allow_unexported.go
+++ b/cmp/cmpopts/deep_allow_unexported.go
@@ -1,0 +1,65 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// DeepAllowUnexporeted creates a cmp.Option that recursively allows unexported
+// fields in the passed types.
+//
+// NOTE: Prefer to explicitly allow structs with internal types via
+// `cmp.AllowUnexported` rather than using this option. The philosophy behind this
+// is that the test writer should know explicitly what they are comparing, and
+// provide an explicit whitelist
+func DeepAllowUnexported(vs ...interface{}) cmp.Option {
+	m := make(map[reflect.Type]struct{})
+	for _, v := range vs {
+		structTypes(reflect.ValueOf(v), m)
+	}
+	var typs []interface{}
+	for t := range m {
+		typs = append(typs, reflect.New(t).Elem().Interface())
+	}
+	return cmp.AllowUnexported(typs...)
+}
+
+func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
+	if !v.IsValid() {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Ptr:
+		if !v.IsNil() {
+			structTypes(v.Elem(), m)
+		}
+	case reflect.Interface:
+		if !v.IsNil() {
+			structTypes(v.Elem(), m)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			structTypes(v.Index(i), m)
+		}
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			structTypes(v.MapIndex(k), m)
+		}
+	case reflect.Struct:
+		// Stop iterating if a cycle is detected. Structs with recursive types
+		// causes a stack overflow in cmp.Equal if their values form a cycle but
+		// DeepAllowUnexported should support them.
+		if _, ok := m[v.Type()]; ok {
+			return
+		}
+		m[v.Type()] = struct{}{}
+		for i := 0; i < v.NumField(); i++ {
+			structTypes(v.Field(i), m)
+		}
+	}
+}

--- a/cmp/cmpopts/deep_allow_unexported_test.go
+++ b/cmp/cmpopts/deep_allow_unexported_test.go
@@ -1,0 +1,136 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDeepAllowUnexported(t *testing.T) {
+	type unexported1 struct {
+		a int
+	}
+	type unexported2 struct {
+		a int
+		b unexported1
+	}
+	type unexportedRecursive struct {
+		a unexported2
+		b *unexportedRecursive
+	}
+
+	u1 := unexported1{a: 1}
+	u2 := unexported2{a: 2, b: u1}
+	u3 := unexportedRecursive{
+		a: u2,
+		b: &unexportedRecursive{
+			a: u2,
+		},
+	}
+
+	t.Run("raw", func(t *testing.T) {
+		t.Run("unexported", func(t *testing.T) {
+			v := u1
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported nested", func(t *testing.T) {
+			v := u2
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported recursive", func(t *testing.T) {
+			v := u3
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+	})
+	t.Run("pointer", func(t *testing.T) {
+		t.Run("unexported", func(t *testing.T) {
+			v := &u1
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported nested", func(t *testing.T) {
+			v := &u2
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported recursive", func(t *testing.T) {
+			v := &u3
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+	})
+	t.Run("interface", func(t *testing.T) {
+		type iface interface{}
+		t.Run("unexported", func(t *testing.T) {
+			v := iface(u1)
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported nested", func(t *testing.T) {
+			v := iface(u2)
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported recursive", func(t *testing.T) {
+			v := iface(u3)
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+	})
+	t.Run("slice", func(t *testing.T) {
+		t.Run("unexported", func(t *testing.T) {
+			v := []unexported1{u1}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported nested", func(t *testing.T) {
+			v := []unexported2{u2}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported recursive", func(t *testing.T) {
+			v := []unexportedRecursive{u3}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+	})
+	t.Run("map value", func(t *testing.T) {
+		t.Run("unexported", func(t *testing.T) {
+			v := map[string]unexported1{"have": u1}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported nested", func(t *testing.T) {
+			v := map[string]unexported2{"have": u2}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+		t.Run("unexported recursive", func(t *testing.T) {
+			v := map[string]unexportedRecursive{"have": u3}
+			if ok := cmp.Equal(v, v, DeepAllowUnexported(v, v)); !ok {
+				t.Errorf("expected types to be equal but saw diff:\n%s", cmp.Diff(v, v, DeepAllowUnexported(v, v)))
+			}
+		})
+	})
+}


### PR DESCRIPTION
With a big note on its usage. This can sometimes be useful. We would like to migrate some of the diffing functionality we reimplement in k8s.io/kubernetes to use this library:

https://github.com/kubernetes/kubernetes/blob/3bcbc5da79978fd48525af82da03434f81e1cdd9/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go#L172

This option would give us a backwards compatible of our current API and allow us to move off of it incrementally and onto direct usage of cmp. We are unsure whether to copy this utility to k8s or add it here.

Fixes: https://github.com/google/go-cmp/issues/40

cc @awly