### PR TITLE
Remove special-case build tags

### DIFF
--- a/cmp/unsafe_panic.go
+++ b/cmp/unsafe_panic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build purego appengine js
+// +build purego
 
 package cmp
 

--- a/cmp/unsafe_reflect.go
+++ b/cmp/unsafe_reflect.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build !purego,!appengine,!js
+// +build !purego
 
 package cmp
 


### PR DESCRIPTION
The purego tag should cover all environments (e.g., gopherjs and appengine)
that do not support unsafe.