### PR TITLE
Make debug mode more explicit

### DIFF
--- a/cmp/internal/diff/debug_disable.go
+++ b/cmp/internal/diff/debug_disable.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build !debug
+// +build !cmp_debug
 
 package diff
 

--- a/cmp/internal/diff/debug_enable.go
+++ b/cmp/internal/diff/debug_enable.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE.md file.
 
-// +build debug
+// +build cmp_debug
 
 package diff
 
@@ -14,7 +14,7 @@ import (
 )
 
 // The algorithm can be seen running in real-time by enabling debugging:
-//	go test -tags=debug -v
+//	go test -tags=cmp_debug -v
 //
 // Example output:
 //	=== RUN   TestDifference/#34

--- a/cmp/internal/diff/diff.go
+++ b/cmp/internal/diff/diff.go
@@ -191,9 +191,9 @@ func Difference(nx, ny int, f EqualFunc) (es EditScript) {
 	// that two lists commonly differ because elements were added to the front
 	// or end of the other list.
 	//
-	// Running the tests with the "debug" build tag prints a visualization of
-	// the algorithm running in real-time. This is educational for understanding
-	// how the algorithm works. See debug_enable.go.
+	// Running the tests with the "cmp_debug" build tag prints a visualization
+	// of the algorithm running in real-time. This is educational for
+	// understanding how the algorithm works. See debug_enable.go.
 	f = debug.Begin(nx, ny, f, &fwdPath.es, &revPath.es)
 	for {
 		// Forward search from the beginning.


### PR DESCRIPTION
Switch the build tag for debugging from "debug" to "cmp_debug".
The former tag accidentally matches usages of that tag for unrelated projects.

Fixes #104