### PR TITLE
Move function name logic to function package

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -346,8 +346,7 @@ func (s *state) callTRFunc(f, v reflect.Value) reflect.Value {
 		if !s.statelessCompare(want, want).Equal() {
 			return want
 		}
-		fn := getFuncName(f.Pointer())
-		panic(fmt.Sprintf("non-deterministic function detected: %s", fn))
+		panic(fmt.Sprintf("non-deterministic function detected: %s", function.NameOf(f)))
 	}
 	return want
 }
@@ -367,8 +366,7 @@ func (s *state) callTTBFunc(f, x, y reflect.Value) bool {
 	go detectRaces(c, f, y, x)
 	want := f.Call([]reflect.Value{x, y})[0].Bool()
 	if got := <-c; !got.IsValid() || got.Bool() != want {
-		fn := getFuncName(f.Pointer())
-		panic(fmt.Sprintf("non-deterministic or non-symmetric function detected: %s", fn))
+		panic(fmt.Sprintf("non-deterministic or non-symmetric function detected: %s", function.NameOf(f)))
 	}
 	return want
 }

--- a/cmp/internal/function/func_test.go
+++ b/cmp/internal/function/func_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package function
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+type myType struct{ bytes.Buffer }
+
+func (myType) valueMethod() {}
+func (myType) ValueMethod() {}
+
+func (*myType) pointerMethod() {}
+func (*myType) PointerMethod() {}
+
+func TestNameOf(t *testing.T) {
+	tests := []struct {
+		fnc  interface{}
+		want string
+	}{
+		{TestNameOf, "function.TestNameOf"},
+		{func() {}, "function.TestNameOf.func1"},
+		{(myType).valueMethod, "function.myType.valueMethod"},
+		{(myType).ValueMethod, "function.myType.ValueMethod"},
+		{(myType{}).valueMethod, "function.myType.valueMethod"},
+		{(myType{}).ValueMethod, "function.myType.ValueMethod"},
+		{(*myType).valueMethod, "function.myType.valueMethod"},
+		{(*myType).ValueMethod, "function.myType.ValueMethod"},
+		{(&myType{}).valueMethod, "function.myType.valueMethod"},
+		{(&myType{}).ValueMethod, "function.myType.ValueMethod"},
+		{(*myType).pointerMethod, "function.myType.pointerMethod"},
+		{(*myType).PointerMethod, "function.myType.PointerMethod"},
+		{(&myType{}).pointerMethod, "function.myType.pointerMethod"},
+		{(&myType{}).PointerMethod, "function.myType.PointerMethod"},
+		{(*myType).Write, "function.myType.Write"},
+		{(&myType{}).Write, "bytes.Buffer.Write"},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := NameOf(reflect.ValueOf(tt.fnc))
+			if got != tt.want {
+				t.Errorf("NameOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmp/options.go
+++ b/cmp/options.go
@@ -7,7 +7,6 @@ package cmp
 import (
 	"fmt"
 	"reflect"
-	"runtime"
 	"strings"
 
 	"github.com/google/go-cmp/cmp/internal/function"
@@ -132,8 +131,7 @@ func (f pathFilter) filter(s *state, vx, vy reflect.Value, t reflect.Type) appli
 }
 
 func (f pathFilter) String() string {
-	fn := getFuncName(reflect.ValueOf(f.fnc).Pointer())
-	return fmt.Sprintf("FilterPath(%s, %v)", fn, f.opt)
+	return fmt.Sprintf("FilterPath(%s, %v)", function.NameOf(reflect.ValueOf(f.fnc)), f.opt)
 }
 
 // FilterValues returns a new Option where opt is only evaluated if filter f,
@@ -182,8 +180,7 @@ func (f valuesFilter) filter(s *state, vx, vy reflect.Value, t reflect.Type) app
 }
 
 func (f valuesFilter) String() string {
-	fn := getFuncName(f.fnc.Pointer())
-	return fmt.Sprintf("FilterValues(%s, %v)", fn, f.opt)
+	return fmt.Sprintf("FilterValues(%s, %v)", function.NameOf(f.fnc), f.opt)
 }
 
 // Ignore is an Option that causes all comparisons to be ignored.
@@ -279,7 +276,7 @@ func (tr *transformer) apply(s *state, vx, vy reflect.Value) {
 }
 
 func (tr transformer) String() string {
-	return fmt.Sprintf("Transformer(%s, %s)", tr.name, getFuncName(tr.fnc.Pointer()))
+	return fmt.Sprintf("Transformer(%s, %s)", tr.name, function.NameOf(tr.fnc))
 }
 
 // Comparer returns an Option that determines whether two values are equal
@@ -327,7 +324,7 @@ func (cm *comparer) apply(s *state, vx, vy reflect.Value) {
 }
 
 func (cm comparer) String() string {
-	return fmt.Sprintf("Comparer(%s)", getFuncName(cm.fnc.Pointer()))
+	return fmt.Sprintf("Comparer(%s)", function.NameOf(cm.fnc))
 }
 
 // AllowUnexported returns an Option that forcibly allows operations on
@@ -426,31 +423,4 @@ func flattenOptions(dst, src Options) Options {
 		}
 	}
 	return dst
-}
-
-// getFuncName returns a short function name from the pointer.
-// The string parsing logic works up until Go1.9.
-func getFuncName(p uintptr) string {
-	fnc := runtime.FuncForPC(p)
-	if fnc == nil {
-		return "<unknown>"
-	}
-	name := fnc.Name() // E.g., "long/path/name/mypkg.(mytype).(long/path/name/mypkg.myfunc)-fm"
-	if strings.HasSuffix(name, ")-fm") || strings.HasSuffix(name, ")·fm") {
-		// Strip the package name from method name.
-		name = strings.TrimSuffix(name, ")-fm")
-		name = strings.TrimSuffix(name, ")·fm")
-		if i := strings.LastIndexByte(name, '('); i >= 0 {
-			methodName := name[i+1:] // E.g., "long/path/name/mypkg.myfunc"
-			if j := strings.LastIndexByte(methodName, '.'); j >= 0 {
-				methodName = methodName[j+1:] // E.g., "myfunc"
-			}
-			name = name[:i] + methodName // E.g., "long/path/name/mypkg.(mytype)." + "myfunc"
-		}
-	}
-	if i := strings.LastIndexByte(name, '/'); i >= 0 {
-		// Strip the package name.
-		name = name[i+1:] // E.g., "mypkg.(mytype).myfunc"
-	}
-	return name
 }


### PR DESCRIPTION
Adjust the logic of NameOf for more recent versions of Go.