### PR TITLE
Always ignore _ fields

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -493,6 +493,9 @@ func (s *state) compareStruct(vx, vy reflect.Value, t reflect.Type) {
 		step.idx = i
 		step.unexported = !isExported(step.name)
 		if step.unexported {
+			if step.name == "_" {
+				continue
+			}
 			// Defer checking of unexported fields until later to give an
 			// Ignore a chance to ignore the field.
 			if !vax.IsValid() || !vay.IsValid() {

--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -465,6 +465,10 @@ root[0]["hr"]:
 root[1]["hr"]:
 	-: int(63)
 	+: float64(63)`,
+	}, {
+		label: label,
+		x:     struct{ _ string }{},
+		y:     struct{ _ string }{},
 	}}
 }
 


### PR DESCRIPTION
The _ field in Go is special in that it cannot be read from or written to.
Thus, skip it by default. It is pointless to require the user to use
cmpopts.IgnoreUnexported just for the _ field.