### PR TITLE
Relax Transformer name rules

### DIFF
--- a/cmp/options_test.go
+++ b/cmp/options_test.go
@@ -113,10 +113,9 @@ func TestOptionPanic(t *testing.T) {
 		args:      []interface{}{"/*", func(int) bool { return true }},
 		wantPanic: "invalid name",
 	}, {
-		label:     "Transformer",
-		fnc:       Transformer,
-		args:      []interface{}{"_", func(int) bool { return true }},
-		wantPanic: "invalid name",
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"_", func(int) bool { return true }},
 	}, {
 		label:     "FilterPath",
 		fnc:       FilterPath,

--- a/cmp/path.go
+++ b/cmp/path.go
@@ -296,14 +296,3 @@ func isExported(id string) bool {
 	r, _ := utf8.DecodeRuneInString(id)
 	return unicode.IsUpper(r)
 }
-
-// isValid reports whether the identifier is valid.
-// Empty and underscore-only strings are not valid.
-func isValid(id string) bool {
-	ok := id != "" && id != "_"
-	for j, c := range id {
-		ok = ok && (j > 0 || !unicode.IsDigit(c))
-		ok = ok && (c == '_' || unicode.IsLetter(c) || unicode.IsDigit(c))
-	}
-	return ok
-}


### PR DESCRIPTION
Relax the Transformer name to be any Go identifier or qualified identifier.
Clarify in the documentation how this is used (e.g., in Diff) and
what names are valid.

Fixes #102