### PR TITLE
Refactor reporter implementation

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -335,7 +335,7 @@ root:
 		x:     new(fmt.Stringer),
 		y:     nil,
 		wantDiff: `
-:
+root:
 	-: &<nil>
 	+: <non-existent>`,
 	}, {
@@ -426,7 +426,7 @@ root:
 		// Ensure Stringer avoids double-quote escaping if possible.
 		label:    label,
 		x:        []*pb.Stringer{{`multi\nline\nline\nline`}},
-		wantDiff: ":\n\t-: []*testprotos.Stringer{s`multi\\nline\\nline\\nline`}\n\t+: <non-existent>",
+		wantDiff: "root:\n\t-: []*testprotos.Stringer{s`multi\\nline\\nline\\nline`}\n\t+: <non-existent>",
 	}, {
 		label: label,
 		x:     struct{ I Iface2 }{},


### PR DESCRIPTION
Switch the internal interface for reporting to use a push-pop mechanism.
This API is strictly more flexible than the previous Report-only API since it
enables the reporter to re-construct the entire value tree.

This change is done in preparation for a major overhaul of reporter logic.