### PR TITLE
Rename unsafe_x.go as export_x.go

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -298,10 +298,9 @@ func (s *state) compareAny(vx, vy reflect.Value) {
 func (s *state) tryExporting(vx, vy reflect.Value) (reflect.Value, reflect.Value) {
 	if sf, ok := s.curPath[len(s.curPath)-1].(*structField); ok && sf.unexported {
 		if sf.force {
-			// Use unsafe pointer arithmetic to get read-write access to an
-			// unexported field in the struct.
-			vx = unsafeRetrieveField(sf.pvx, sf.field)
-			vy = unsafeRetrieveField(sf.pvy, sf.field)
+			// Forcibly obtain read-write access to an unexported struct field.
+			vx = retrieveUnexportedField(sf.pvx, sf.field)
+			vy = retrieveUnexportedField(sf.pvy, sf.field)
 		} else {
 			// We are not allowed to export the value, so invalidate them
 			// so that tryOptions can panic later if not explicitly ignored.
@@ -423,7 +422,7 @@ func (s *state) compareStruct(vx, vy reflect.Value, t reflect.Type) {
 			// Defer checking of unexported fields until later to give an
 			// Ignore a chance to ignore the field.
 			if !vax.IsValid() || !vay.IsValid() {
-				// For unsafeRetrieveField to work, the parent struct must
+				// For retrieveUnexportedField to work, the parent struct must
 				// be addressable. Create a new copy of the values if
 				// necessary to make them addressable.
 				vax = makeAddressable(vx)

--- a/cmp/export_panic.go
+++ b/cmp/export_panic.go
@@ -10,6 +10,6 @@ import "reflect"
 
 const supportAllowUnexported = false
 
-func unsafeRetrieveField(reflect.Value, reflect.StructField) reflect.Value {
-	panic("unsafeRetrieveField is not implemented")
+func retrieveUnexportedField(reflect.Value, reflect.StructField) reflect.Value {
+	panic("retrieveUnexportedField is not implemented")
 }

--- a/cmp/export_unsafe.go
+++ b/cmp/export_unsafe.go
@@ -13,11 +13,11 @@ import (
 
 const supportAllowUnexported = true
 
-// unsafeRetrieveField uses unsafe to forcibly retrieve any field from a struct
-// such that the value has read-write permissions.
+// retrieveUnexportedField uses unsafe to forcibly retrieve any field from
+// a struct such that the value has read-write permissions.
 //
 // The parent struct, v, must be addressable, while f must be a StructField
 // describing the field to retrieve.
-func unsafeRetrieveField(v reflect.Value, f reflect.StructField) reflect.Value {
+func retrieveUnexportedField(v reflect.Value, f reflect.StructField) reflect.Value {
 	return reflect.NewAt(f.Type, unsafe.Pointer(v.UnsafeAddr()+f.Offset)).Elem()
 }


### PR DESCRIPTION
Rename the file based on what it does rather than how its implemented.