### PR TITLE
Evaluate options even if values are invalid

### DIFF
--- a/cmp/options.go
+++ b/cmp/options.go
@@ -106,6 +106,11 @@ func (opts Options) String() string {
 // FilterPath returns a new Option where opt is only evaluated if filter f
 // returns true for the current Path in the value tree.
 //
+// This filter is called even if a slice element or map entry is missing and
+// provides an opportunity to ignore such cases. The filter function must be
+// symmetric such that the filter result is identical regardless of whether the
+// missing value is from x or y.
+//
 // The option passed in may be an Ignore, Transformer, Comparer, Options, or
 // a previously filtered Option.
 func FilterPath(f func(Path) bool, opt Option) Option {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/google/go-cmp
+
+go 1.8


### PR DESCRIPTION
Rather than checking up-front whether the values are invalid,
give tryOptions a chance to operate on them and potentially ignore
the values. This is useful since a value can only be invalid if it
is a missing slice element or map entry, and provides FilterPath
combined with Ignore the ability to ignore such cases.

Some complexity is added to compareSlice to look for ignored elements
first before applying diffing so that we can decouple the stability
of the diffing algorithm from the primary result.