### PR TITLE
Augment Report to indicate how comparison was determined

### DIFF
--- a/cmp/options_test.go
+++ b/cmp/options_test.go
@@ -128,7 +128,7 @@ func TestOptionPanic(t *testing.T) {
 	}, {
 		label:     "FilterPath",
 		fnc:       FilterPath,
-		args:      []interface{}{func(Path) bool { return true }, &defaultReporter{}},
+		args:      []interface{}{func(Path) bool { return true }, reporter(&defaultReporter{})},
 		wantPanic: "invalid option type",
 	}, {
 		label: "FilterPath",
@@ -137,7 +137,7 @@ func TestOptionPanic(t *testing.T) {
 	}, {
 		label:     "FilterPath",
 		fnc:       FilterPath,
-		args:      []interface{}{func(Path) bool { return true }, Options{Ignore(), &defaultReporter{}}},
+		args:      []interface{}{func(Path) bool { return true }, Options{Ignore(), reporter(&defaultReporter{})}},
 		wantPanic: "invalid option type",
 	}, {
 		label:     "FilterValues",
@@ -170,7 +170,7 @@ func TestOptionPanic(t *testing.T) {
 	}, {
 		label:     "FilterValues",
 		fnc:       FilterValues,
-		args:      []interface{}{func(int, int) bool { return true }, &defaultReporter{}},
+		args:      []interface{}{func(int, int) bool { return true }, reporter(&defaultReporter{})},
 		wantPanic: "invalid option type",
 	}, {
 		label: "FilterValues",
@@ -179,7 +179,7 @@ func TestOptionPanic(t *testing.T) {
 	}, {
 		label:     "FilterValues",
 		fnc:       FilterValues,
-		args:      []interface{}{func(int, int) bool { return true }, Options{Ignore(), &defaultReporter{}}},
+		args:      []interface{}{func(int, int) bool { return true }, Options{Ignore(), reporter(&defaultReporter{})}},
 		wantPanic: "invalid option type",
 	}}
 

--- a/cmp/report.go
+++ b/cmp/report.go
@@ -13,8 +13,6 @@ import (
 )
 
 type defaultReporter struct {
-	Option
-
 	curPath Path
 
 	diffs  []string // List of differences, possibly truncated
@@ -27,7 +25,7 @@ func (r *defaultReporter) PushStep(ps PathStep) {
 	r.curPath.push(ps)
 }
 func (r *defaultReporter) Report(f reportFlags) {
-	if f == reportUnequal {
+	if f&reportUnequal > 0 {
 		vx, vy := r.curPath.Last().Values()
 		r.report(vx, vy, r.curPath)
 	}


### PR DESCRIPTION
This is necessary for the upcoming reporter re-implementation so that
it can format the differences with more intelligence.
No tests added in this PR since an upcoming change will heavily test
these code paths.