### PR TITLE
Add IgnoreSliceElements and IgnoreMapEntries helpers

### DIFF
--- a/cmp/cmpopts/ignore.go
+++ b/cmp/cmpopts/ignore.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
 )
 
 // IgnoreFields returns an Option that ignores exported fields of the
@@ -146,4 +147,61 @@ func (xf unexportedFilter) filter(p cmp.Path) bool {
 func isExported(id string) bool {
 	r, _ := utf8.DecodeRuneInString(id)
 	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
 }

--- a/cmp/cmpopts/sort.go
+++ b/cmp/cmpopts/sort.go
@@ -26,10 +26,10 @@ import (
 // !less(y, x) for two elements x and y, their relative order is maintained.
 //
 // SortSlices can be used in conjunction with EquateEmpty.
-func SortSlices(less interface{}) cmp.Option {
-	vf := reflect.ValueOf(less)
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
 	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
-		panic(fmt.Sprintf("invalid less function: %T", less))
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
 	}
 	ss := sliceSorter{vf.Type().In(0), vf}
 	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
@@ -97,10 +97,10 @@ func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
 //	• Total: if x != y, then either less(x, y) or less(y, x)
 //
 // SortMaps can be used in conjunction with EquateEmpty.
-func SortMaps(less interface{}) cmp.Option {
-	vf := reflect.ValueOf(less)
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
 	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
-		panic(fmt.Sprintf("invalid less function: %T", less))
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
 	}
 	ms := mapSorter{vf.Type().In(0), vf}
 	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))

--- a/cmp/cmpopts/xform.go
+++ b/cmp/cmpopts/xform.go
@@ -29,7 +29,7 @@ func (xf xformFilter) filter(p cmp.Path) bool {
 //
 // Had this been an unfiltered Transformer instead, this would result in an
 // infinite cycle converting a string to []string to [][]string and so on.
-func AcyclicTransformer(name string, f interface{}) cmp.Option {
-	xf := xformFilter{cmp.Transformer(name, f)}
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
 	return cmp.FilterPath(xf.filter, xf.xform)
 }

--- a/cmp/internal/function/func.go
+++ b/cmp/internal/function/func.go
@@ -17,15 +17,19 @@ type funcType int
 const (
 	_ funcType = iota
 
+	tbFunc  // func(T) bool
 	ttbFunc // func(T, T) bool
+	trbFunc // func(T, R) bool
 	tibFunc // func(T, I) bool
 	trFunc  // func(T) R
 
-	Equal           = ttbFunc // func(T, T) bool
-	EqualAssignable = tibFunc // func(T, I) bool; encapsulates func(T, T) bool
-	Transformer     = trFunc  // func(T) R
-	ValueFilter     = ttbFunc // func(T, T) bool
-	Less            = ttbFunc // func(T, T) bool
+	Equal             = ttbFunc // func(T, T) bool
+	EqualAssignable   = tibFunc // func(T, I) bool; encapsulates func(T, T) bool
+	Transformer       = trFunc  // func(T) R
+	ValueFilter       = ttbFunc // func(T, T) bool
+	Less              = ttbFunc // func(T, T) bool
+	ValuePredicate    = tbFunc  // func(T) bool
+	KeyValuePredicate = trbFunc // func(T, R) bool
 )
 
 var boolType = reflect.TypeOf(true)
@@ -37,8 +41,16 @@ func IsType(t reflect.Type, ft funcType) bool {
 	}
 	ni, no := t.NumIn(), t.NumOut()
 	switch ft {
+	case tbFunc: // func(T) bool
+		if ni == 1 && no == 1 && t.Out(0) == boolType {
+			return true
+		}
 	case ttbFunc: // func(T, T) bool
 		if ni == 2 && no == 1 && t.In(0) == t.In(1) && t.Out(0) == boolType {
+			return true
+		}
+	case trbFunc: // func(T, R) bool
+		if ni == 2 && no == 1 && t.Out(0) == boolType {
 			return true
 		}
 	case tibFunc: // func(T, I) bool


### PR DESCRIPTION
These helper options ignore slice elements or map entries based
on a user-provided predicate function. These are especially useful
for ignoring missing elements or entries.