### PR TITLE
Invoke String when formatting map keys 

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -518,7 +518,7 @@ func comparerTests() []test {
 		y:     map[*pb.Stringer]*pb.Stringer(nil),
 		wantDiff: `
   map[*testprotos.Stringer]*testprotos.Stringer(
-- 	{⟪0xdeadf00f⟫: s"world"},
+- 	{s"hello": s"world"},
 + 	nil,
   )
 `,

--- a/cmp/report_reflect.go
+++ b/cmp/report_reflect.go
@@ -208,7 +208,6 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 func formatMapKey(v reflect.Value) string {
 	var opts formatOptions
 	opts.TypeMode = elideType
-	opts.AvoidStringer = true
 	opts.ShallowPointers = true
 	s := opts.FormatValue(v, visitedPointers{}).String()
 	return strings.TrimSpace(s)


### PR DESCRIPTION
This reverts a change introduced in commit 2940eda701 where the
cmp package stopped calling the String method when printing map
keys. The motivation for the change is unclear, indeed there was
a pre-existing test that String was called on map keys that the
commit changed.

Fixes #141