### PR TITLE
Fix ineffectual assignment to lastLineIdx

### DIFF
--- a/cmp/report_slices.go
+++ b/cmp/report_slices.go
@@ -90,7 +90,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 			}
 			if r == '\n' {
 				if maxLineLen < i-lastLineIdx {
-					lastLineIdx = i - lastLineIdx
+					maxLineLen = i - lastLineIdx
 				}
 				lastLineIdx = i + 1
 				numLines++


### PR DESCRIPTION
Please review this thoroughly, I'm not sure I can properly test this change.
However I noticed that the assignment to lastLineIdx in line 93 is ineffectual,
as it'll always get overwritten in the line below. I can only assume this
either means the else-block was missing (which is what I'm fixing here), or it's
an old check that's just lingering around and was forgotten to be removed during
refactoring.