### PR TITLE
Fixed typo in formatDiffList

### DIFF
--- a/cmp/report_compare.go
+++ b/cmp/report_compare.go
@@ -168,7 +168,7 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 				var isZero bool
 				switch opts.DiffMode {
 				case diffIdentical:
-					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueX)
+					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueY)
 				case diffRemoved:
 					isZero = value.IsZero(r.Value.ValueX)
 				case diffInserted:


### PR DESCRIPTION
I assume this is a typo, as the left and right side of the boolean-or were
identical. Please thoroughly review this.