### PR TITLE
Simplify code

### DIFF
--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -806,7 +806,7 @@ func TestOptions(t *testing.T) {
 		x:     []string{"foo", "Bar", "BAZ"},
 		y:     []string{"Foo", "BAR", "baz"},
 		opts: []cmp.Option{
-			AcyclicTransformer("", func(s string) string { return strings.ToUpper(s) }),
+			AcyclicTransformer("", strings.ToUpper),
 		},
 		wantEqual: true,
 		reason:    "equal because of strings.ToUpper; AcyclicTransformer unnecessary, but check this still works",
@@ -815,7 +815,7 @@ func TestOptions(t *testing.T) {
 		x:     "this is a sentence",
 		y: "this   			is a 			sentence",
 		opts: []cmp.Option{
-			AcyclicTransformer("", func(s string) []string { return strings.Fields(s) }),
+			AcyclicTransformer("", strings.Fields),
 		},
 		wantEqual: true,
 		reason:    "equal because acyclic transformer splits on any contiguous whitespace",

--- a/cmp/report_slices.go
+++ b/cmp/report_slices.go
@@ -322,7 +322,7 @@ func coalesceInterveningIdentical(groups []diffStats, windowSize int) []diffStat
 			hadX, hadY := prev.NumRemoved > 0, prev.NumInserted > 0
 			hasX, hasY := next.NumRemoved > 0, next.NumInserted > 0
 			if ((hadX || hasX) && (hadY || hasY)) && curr.NumIdentical <= windowSize {
-				*prev = (*prev).Append(*curr).Append(*next)
+				*prev = prev.Append(*curr).Append(*next)
 				groups = groups[:len(groups)-1] // Truncate off equal group
 				continue
 			}

--- a/cmp/report_text.go
+++ b/cmp/report_text.go
@@ -365,7 +365,7 @@ func (s diffStats) String() string {
 	// Pluralize the name (adjusting for some obscure English grammar rules).
 	name := s.Name
 	if sum > 1 {
-		name = name + "s"
+		name += "s"
 		if strings.HasSuffix(name, "ys") {
 			name = name[:len(name)-2] + "ies" // e.g., "entrys" => "entries"
 		}


### PR DESCRIPTION
- No need to wrap ToUpper & Fields
- Simpler concatenation
- Easier pointer access