### PR TITLE
cmp: make retrieveUnexportedField pass Go 1.14's upcoming checkptr validation

### DIFF
--- a/cmp/export_unsafe.go
+++ b/cmp/export_unsafe.go
@@ -19,5 +19,7 @@ const supportAllowUnexported = true
 // The parent struct, v, must be addressable, while f must be a StructField
 // describing the field to retrieve.
 func retrieveUnexportedField(v reflect.Value, f reflect.StructField) reflect.Value {
-	return reflect.NewAt(f.Type, unsafe.Pointer(v.UnsafeAddr()+f.Offset)).Elem()
+	// See https://github.com/google/go-cmp/issues/167 for discussion of the
+	// following expression.
+	return reflect.NewAt(f.Type, unsafe.Pointer(uintptr(unsafe.Pointer(v.UnsafeAddr()))+f.Offset)).Elem()
 }


### PR DESCRIPTION
Fixes #167