### PR TITLE
Add Exporter option

### DIFF
--- a/cmp/export_panic.go
+++ b/cmp/export_panic.go
@@ -8,8 +8,8 @@ package cmp
 
 import "reflect"
 
-const supportAllowUnexported = false
+const supportExporters = false
 
 func retrieveUnexportedField(reflect.Value, reflect.StructField) reflect.Value {
-	panic("retrieveUnexportedField is not implemented")
+	panic("no support for forcibly accessing unexported fields")
 }

--- a/cmp/export_unsafe.go
+++ b/cmp/export_unsafe.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-const supportAllowUnexported = true
+const supportExporters = true
 
 // retrieveUnexportedField uses unsafe to forcibly retrieve any field from
 // a struct such that the value has read-write permissions.

--- a/cmp/path.go
+++ b/cmp/path.go
@@ -41,7 +41,7 @@ type PathStep interface {
 	// In some cases, one or both may be invalid or have restrictions:
 	//	• For StructField, both are not interface-able if the current field
 	//	is unexported and the struct type is not explicitly permitted by
-	//	AllowUnexported to traverse unexported fields.
+	//	an Exporter to traverse unexported fields.
 	//	• For SliceIndex, one may be invalid if an element is missing from
 	//	either the x or y slice.
 	//	• For MapIndex, one may be invalid if an entry is missing from


### PR DESCRIPTION
Add an Exporter option that accepts a function to determine
which struct types to permit access to unexported fields.
Treat this as a first-class option and implement AllowUnexported
in terms of the new Exporter option.

The new Exporter option:
* Better matches the existing style of top-level options
both by name (e.g., Comparer, Transformer, and Reporter)
and by API style (all accept a function).
* Is more flexible as it enables users to functionally
implement AllowAllUnexported by simply doing:
	Exporter(func(reflect.Type) bool { return true })

Fixes #40