### PR TITLE
Update README.md to use go.dev for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Package for equality of Go values
 
-[![GoDoc](https://godoc.org/github.com/google/go-cmp/cmp?status.svg)][godoc]
+[![GoDev](https://img.shields.io/static/v1?label=godev&message=reference&color=00add8)][godev]
 [![Build Status](https://travis-ci.org/google/go-cmp.svg?branch=master)][travis]
 
 This package is intended to be a more powerful and safer alternative to
@@ -24,11 +24,11 @@ The primary features of `cmp` are:
   by using an `Ignore` option (see `cmpopts.IgnoreUnexported`) or explicitly
   compared using the `AllowUnexported` option.
 
-See the [GoDoc documentation][godoc] for more information.
+See the [documentation][godev] for more information.
 
 This is not an official Google product.
 
-[godoc]: https://godoc.org/github.com/google/go-cmp/cmp
+[godev]: https://pkg.go.dev/github.com/google/go-cmp/cmp
 [travis]: https://travis-ci.org/google/go-cmp
 
 ## Install


### PR DESCRIPTION
The color of the shield banner is "Gopher Blue" as defined by
brand book referenced by the Go blog. See https://blog.golang.org/go-brand