### PR TITLE
Add reporterTests to TestDiff

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -50,6 +50,7 @@ func TestDiff(t *testing.T) {
 	var tests []test
 	tests = append(tests, comparerTests()...)
 	tests = append(tests, transformerTests()...)
+	tests = append(tests, reporterTests()...)
 	tests = append(tests, embeddedTests()...)
 	tests = append(tests, methodTests()...)
 	tests = append(tests, cycleTests()...)


### PR DESCRIPTION
Add because `reporterTests` was missing from `TestDiff`.

Fixes #197.