### PR TITLE
Refactor tests to use golden test files

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -8,8 +8,10 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"reflect"
@@ -33,6 +35,70 @@ func init() {
 	flags.Deterministic = true
 }
 
+var update = flag.Bool("update", false, "update golden test files")
+
+const goldenHeaderPrefix = "<<< "
+const goldenFooterPrefix = ">>> "
+
+/// mustParseGolden parses a file as a set of key-value pairs.
+//
+// The syntax is simple and looks something like:
+//
+//	<<< Key1
+//	value1a
+//	value1b
+//	>>> Key1
+//	<<< Key2
+//	value2
+//	>>> Key2
+//
+// It is the user's responsibility to choose a sufficiently unique key name
+// such that it never appears in the body of the value itself.
+func mustParseGolden(path string) map[string]string {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	s := string(b)
+
+	out := map[string]string{}
+	for len(s) > 0 {
+		// Identify the next header.
+		i := strings.Index(s, "\n") + len("\n")
+		header := s[:i]
+		if !strings.HasPrefix(header, goldenHeaderPrefix) {
+			panic(fmt.Sprintf("invalid header: %q", header))
+		}
+
+		// Locate the next footer.
+		footer := goldenFooterPrefix + header[len(goldenHeaderPrefix):]
+		j := strings.Index(s, footer)
+		if j < 0 {
+			panic(fmt.Sprintf("missing footer: %q", footer))
+		}
+
+		// Store the name and data.
+		name := header[len(goldenHeaderPrefix) : len(header)-len("\n")]
+		if _, ok := out[name]; ok {
+			panic(fmt.Sprintf("duplicate name: %q", name))
+		}
+		out[name] = s[len(header):j]
+		s = s[j+len(footer):]
+	}
+	return out
+}
+func mustFormatGolden(path string, in []struct{ Name, Data string }) {
+	var b []byte
+	for _, v := range in {
+		b = append(b, goldenHeaderPrefix+v.Name+"\n"...)
+		b = append(b, v.Data...)
+		b = append(b, goldenFooterPrefix+v.Name+"\n"...)
+	}
+	if err := ioutil.WriteFile(path, b, 0664); err != nil {
+		panic(err)
+	}
+}
+
 var now = time.Date(2009, time.November, 10, 23, 00, 00, 00, time.UTC)
 
 func intPtr(n int) *int { return &n }
@@ -41,7 +107,7 @@ type test struct {
 	label     string       // Test name
 	x, y      interface{}  // Input values to compare
 	opts      []cmp.Option // Input options
-	wantDiff  string       // The exact difference string
+	wantEqual bool         // Whether any difference is expected
 	wantPanic string       // Sub-string of an expected panic message
 	reason    string       // The reason for the expected outcome
 }
@@ -59,10 +125,15 @@ func TestDiff(t *testing.T) {
 	tests = append(tests, project3Tests()...)
 	tests = append(tests, project4Tests()...)
 
+	const goldenFile = "testdata/diffs"
+	gotDiffs := []struct{ Name, Data string }{}
+	wantDiffs := mustParseGolden(goldenFile)
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.label, func(t *testing.T) {
-			t.Parallel()
+			if !*update {
+				t.Parallel()
+			}
 			var gotDiff, gotPanic string
 			func() {
 				defer func() {
@@ -76,14 +147,25 @@ func TestDiff(t *testing.T) {
 				}()
 				gotDiff = cmp.Diff(tt.x, tt.y, tt.opts...)
 			}()
+
 			// TODO: Require every test case to provide a reason.
 			if tt.wantPanic == "" {
 				if gotPanic != "" {
 					t.Fatalf("unexpected panic message: %s\nreason: %v", gotPanic, tt.reason)
 				}
-				tt.wantDiff = strings.TrimPrefix(tt.wantDiff, "\n")
-				if gotDiff != tt.wantDiff {
-					t.Fatalf("difference message:\ngot:\n%s\nwant:\n%s\nreason: %v", gotDiff, tt.wantDiff, tt.reason)
+				if *update {
+					if gotDiff != "" {
+						gotDiffs = append(gotDiffs, struct{ Name, Data string }{t.Name(), gotDiff})
+					}
+				} else {
+					wantDiff := wantDiffs[t.Name()]
+					if gotDiff != wantDiff {
+						t.Fatalf("Diff:\ngot:\n%s\nwant:\n%s\nreason: %v", gotDiff, wantDiff, tt.reason)
+					}
+				}
+				gotEqual := gotDiff == ""
+				if gotEqual != tt.wantEqual {
+					t.Fatalf("Equal = %v, want %v\nreason: %v", gotEqual, tt.wantEqual, tt.reason)
 				}
 			} else {
 				if !strings.Contains(gotPanic, tt.wantPanic) {
@@ -91,6 +173,10 @@ func TestDiff(t *testing.T) {
 				}
 			}
 		})
+	}
+
+	if *update {
+		mustFormatGolden(goldenFile, gotDiffs)
 	}
 }
 
@@ -140,13 +226,15 @@ func comparerTests() []test {
 	}
 
 	return []test{{
-		label: label,
-		x:     nil,
-		y:     nil,
+		label:     label,
+		x:         nil,
+		y:         nil,
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     1,
-		y:     1,
+		label:     label,
+		x:         1,
+		y:         1,
+		wantEqual: true,
 	}, {
 		label:     label,
 		x:         1,
@@ -185,45 +273,36 @@ func comparerTests() []test {
 			cmp.Comparer(func(x, y int) bool { return true }),
 			cmp.Transformer("λ", func(x int) float64 { return float64(x) }),
 		},
+		wantEqual: true,
 	}, {
 		label:     label,
 		opts:      []cmp.Option{struct{ cmp.Option }{}},
 		wantPanic: "unknown option",
 	}, {
-		label: label,
-		x:     struct{ A, B, C int }{1, 2, 3},
-		y:     struct{ A, B, C int }{1, 2, 3},
+		label:     label,
+		x:         struct{ A, B, C int }{1, 2, 3},
+		y:         struct{ A, B, C int }{1, 2, 3},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     struct{ A, B, C int }{1, 2, 3},
-		y:     struct{ A, B, C int }{1, 2, 4},
-		wantDiff: `
-  struct{ A int; B int; C int }{
-  	A: 1,
-  	B: 2,
-- 	C: 3,
-+ 	C: 4,
-  }
-`,
+		label:     label,
+		x:         struct{ A, B, C int }{1, 2, 3},
+		y:         struct{ A, B, C int }{1, 2, 4},
+		wantEqual: false,
 	}, {
 		label:     label,
 		x:         struct{ a, b, c int }{1, 2, 3},
 		y:         struct{ a, b, c int }{1, 2, 4},
 		wantPanic: "cannot handle unexported field",
 	}, {
-		label: label,
-		x:     &struct{ A *int }{intPtr(4)},
-		y:     &struct{ A *int }{intPtr(4)},
+		label:     label,
+		x:         &struct{ A *int }{intPtr(4)},
+		y:         &struct{ A *int }{intPtr(4)},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     &struct{ A *int }{intPtr(4)},
-		y:     &struct{ A *int }{intPtr(5)},
-		wantDiff: `
-  &struct{ A *int }{
-- 	A: &4,
-+ 	A: &5,
-  }
-`,
+		label:     label,
+		x:         &struct{ A *int }{intPtr(4)},
+		y:         &struct{ A *int }{intPtr(5)},
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     &struct{ A *int }{intPtr(4)},
@@ -231,6 +310,7 @@ func comparerTests() []test {
 		opts: []cmp.Option{
 			cmp.Comparer(func(x, y int) bool { return true }),
 		},
+		wantEqual: true,
 	}, {
 		label: label,
 		x:     &struct{ A *int }{intPtr(4)},
@@ -238,20 +318,17 @@ func comparerTests() []test {
 		opts: []cmp.Option{
 			cmp.Comparer(func(x, y *int) bool { return x != nil && y != nil }),
 		},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     &struct{ R *bytes.Buffer }{},
-		y:     &struct{ R *bytes.Buffer }{},
+		label:     label,
+		x:         &struct{ R *bytes.Buffer }{},
+		y:         &struct{ R *bytes.Buffer }{},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     &struct{ R *bytes.Buffer }{new(bytes.Buffer)},
-		y:     &struct{ R *bytes.Buffer }{},
-		wantDiff: `
-  &struct{ R *bytes.Buffer }{
-- 	R: s"",
-+ 	R: nil,
-  }
-`,
+		label:     label,
+		x:         &struct{ R *bytes.Buffer }{new(bytes.Buffer)},
+		y:         &struct{ R *bytes.Buffer }{},
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     &struct{ R *bytes.Buffer }{new(bytes.Buffer)},
@@ -259,6 +336,7 @@ func comparerTests() []test {
 		opts: []cmp.Option{
 			cmp.Comparer(func(x, y io.Reader) bool { return true }),
 		},
+		wantEqual: true,
 	}, {
 		label:     label,
 		x:         &struct{ R bytes.Buffer }{},
@@ -280,6 +358,7 @@ func comparerTests() []test {
 			cmp.Transformer("Ref", func(x bytes.Buffer) *bytes.Buffer { return &x }),
 			cmp.Comparer(func(x, y io.Reader) bool { return true }),
 		},
+		wantEqual: true,
 	}, {
 		label:     label,
 		x:         []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
@@ -295,6 +374,7 @@ func comparerTests() []test {
 			}
 			return x.String() == y.String()
 		})},
+		wantEqual: true,
 	}, {
 		label: label,
 		x:     []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
@@ -305,13 +385,7 @@ func comparerTests() []test {
 			}
 			return x.String() == y.String()
 		})},
-		wantDiff: `
-  []*regexp.Regexp{
-  	nil,
-- 	s"a*b*c*",
-+ 	s"a*b*d*",
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x: func() ***int {
@@ -326,6 +400,7 @@ func comparerTests() []test {
 			c := &b
 			return &c
 		}(),
+		wantEqual: true,
 	}, {
 		label: label,
 		x: func() ***int {
@@ -340,109 +415,39 @@ func comparerTests() []test {
 			c := &b
 			return &c
 		}(),
-		wantDiff: `
-  &&&int(
-- 	0,
-+ 	1,
-  )
-`,
+		wantEqual: false,
 	}, {
-		label: label,
-		x:     []int{1, 2, 3, 4, 5}[:3],
-		y:     []int{1, 2, 3},
+		label:     label,
+		x:         []int{1, 2, 3, 4, 5}[:3],
+		y:         []int{1, 2, 3},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
-		y:     struct{ fmt.Stringer }{regexp.MustCompile("hello")},
-		opts:  []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
+		label:     label,
+		x:         struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
+		y:         struct{ fmt.Stringer }{regexp.MustCompile("hello")},
+		opts:      []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
-		y:     struct{ fmt.Stringer }{regexp.MustCompile("hello2")},
-		opts:  []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
-		wantDiff: `
-  struct{ fmt.Stringer }(
-- 	s"hello",
-+ 	s"hello2",
-  )
-`,
+		label:     label,
+		x:         struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
+		y:         struct{ fmt.Stringer }{regexp.MustCompile("hello2")},
+		opts:      []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
+		wantEqual: false,
 	}, {
-		label: label,
-		x:     md5.Sum([]byte{'a'}),
-		y:     md5.Sum([]byte{'b'}),
-		wantDiff: `
-  [16]uint8{
-- 	0x0c, 0xc1, 0x75, 0xb9, 0xc0, 0xf1, 0xb6, 0xa8, 0x31, 0xc3, 0x99, 0xe2, 0x69, 0x77, 0x26, 0x61,
-+ 	0x92, 0xeb, 0x5f, 0xfe, 0xe6, 0xae, 0x2f, 0xec, 0x3a, 0xd7, 0x1c, 0x77, 0x75, 0x31, 0x57, 0x8f,
-  }
-`,
+		label:     label,
+		x:         md5.Sum([]byte{'a'}),
+		y:         md5.Sum([]byte{'b'}),
+		wantEqual: false,
 	}, {
-		label: label,
-		x:     new(fmt.Stringer),
-		y:     nil,
-		wantDiff: `
-  interface{}(
-- 	&fmt.Stringer(nil),
-  )
-`,
+		label:     label,
+		x:         new(fmt.Stringer),
+		y:         nil,
+		wantEqual: false,
 	}, {
-		label: label,
-		x:     makeTarHeaders('0'),
-		y:     makeTarHeaders('\x00'),
-		wantDiff: `
-  []cmp_test.tarHeader{
-  	{
-  		... // 4 identical fields
-  		Size:     1,
-  		ModTime:  s"2009-11-10 23:00:00 +0000 UTC",
-- 		Typeflag: 0x30,
-+ 		Typeflag: 0x00,
-  		Linkname: "",
-  		Uname:    "user",
-  		... // 6 identical fields
-  	},
-  	{
-  		... // 4 identical fields
-  		Size:     2,
-  		ModTime:  s"2009-11-11 00:00:00 +0000 UTC",
-- 		Typeflag: 0x30,
-+ 		Typeflag: 0x00,
-  		Linkname: "",
-  		Uname:    "user",
-  		... // 6 identical fields
-  	},
-  	{
-  		... // 4 identical fields
-  		Size:     4,
-  		ModTime:  s"2009-11-11 01:00:00 +0000 UTC",
-- 		Typeflag: 0x30,
-+ 		Typeflag: 0x00,
-  		Linkname: "",
-  		Uname:    "user",
-  		... // 6 identical fields
-  	},
-  	{
-  		... // 4 identical fields
-  		Size:     8,
-  		ModTime:  s"2009-11-11 02:00:00 +0000 UTC",
-- 		Typeflag: 0x30,
-+ 		Typeflag: 0x00,
-  		Linkname: "",
-  		Uname:    "user",
-  		... // 6 identical fields
-  	},
-  	{
-  		... // 4 identical fields
-  		Size:     16,
-  		ModTime:  s"2009-11-11 03:00:00 +0000 UTC",
-- 		Typeflag: 0x30,
-+ 		Typeflag: 0x00,
-  		Linkname: "",
-  		Uname:    "user",
-  		... // 6 identical fields
-  	},
-  }
-`,
+		label:     label,
+		x:         makeTarHeaders('0'),
+		y:         makeTarHeaders('\x00'),
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     make([]int, 1000),
@@ -494,50 +499,18 @@ func comparerTests() []test {
 				return math.NaN()
 			}),
 		},
-		wantDiff: `
-  []int{
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-- 	Inverse(λ, float64(NaN)),
-+ 	Inverse(λ, float64(NaN)),
-  }
-`,
+		wantEqual: false,
 	}, {
 		// Ensure reasonable Stringer formatting of map keys.
-		label: label,
-		x:     map[*pb.Stringer]*pb.Stringer{{"hello"}: {"world"}},
-		y:     map[*pb.Stringer]*pb.Stringer(nil),
-		wantDiff: `
-  map[*testprotos.Stringer]*testprotos.Stringer(
-- 	{s"hello": s"world"},
-+ 	nil,
-  )
-`,
+		label:     label,
+		x:         map[*pb.Stringer]*pb.Stringer{{"hello"}: {"world"}},
+		y:         map[*pb.Stringer]*pb.Stringer(nil),
+		wantEqual: false,
 	}, {
 		// Ensure Stringer avoids double-quote escaping if possible.
-		label: label,
-		x:     []*pb.Stringer{{`multi\nline\nline\nline`}},
-		wantDiff: strings.Replace(`
-  interface{}(
-- 	[]*testprotos.Stringer{s'multi\nline\nline\nline'},
-  )
-`, "'", "`", -1),
+		label:     label,
+		x:         []*pb.Stringer{{`multi\nline\nline\nline`}},
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     struct{ I Iface2 }{},
@@ -547,6 +520,7 @@ func comparerTests() []test {
 				return x == nil && y == nil
 			}),
 		},
+		wantEqual: true,
 	}, {
 		label: label,
 		x:     struct{ I Iface2 }{},
@@ -556,6 +530,7 @@ func comparerTests() []test {
 				return v == nil
 			}),
 		},
+		wantEqual: true,
 	}, {
 		label: label,
 		x:     struct{ I Iface2 }{},
@@ -565,26 +540,12 @@ func comparerTests() []test {
 				return x == nil && y == nil
 			}, cmp.Ignore()),
 		},
+		wantEqual: true,
 	}, {
-		label: label,
-		x:     []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63, "name": "Sammy Sosa"}},
-		y:     []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65.0, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63.0, "name": "Sammy Sosa"}},
-		wantDiff: `
-  []interface{}{
-  	map[string]interface{}{
-  		"avg":  float64(0.278),
-- 		"hr":   int(65),
-+ 		"hr":   float64(65),
-  		"name": string("Mark McGwire"),
-  	},
-  	map[string]interface{}{
-  		"avg":  float64(0.288),
-- 		"hr":   int(63),
-+ 		"hr":   float64(63),
-  		"name": string("Sammy Sosa"),
-  	},
-  }
-`,
+		label:     label,
+		x:         []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63, "name": "Sammy Sosa"}},
+		y:         []interface{}{map[string]interface{}{"avg": 0.278, "hr": 65.0, "name": "Mark McGwire"}, map[string]interface{}{"avg": 0.288, "hr": 63.0, "name": "Sammy Sosa"}},
+		wantEqual: false,
 	}, {
 		label: label,
 		x: map[*int]string{
@@ -593,12 +554,7 @@ func comparerTests() []test {
 		y: map[*int]string{
 			new(int): "world",
 		},
-		wantDiff: `
-  map[*int]string{
-- 	⟪0xdeadf00f⟫: "hello",
-+ 	⟪0xdeadf00f⟫: "world",
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     intPtr(0),
@@ -606,13 +562,8 @@ func comparerTests() []test {
 		opts: []cmp.Option{
 			cmp.Comparer(func(x, y *int) bool { return x == y }),
 		},
-		// TODO: This output is unhelpful and should show the address.
-		wantDiff: `
-  (*int)(
-- 	&0,
-+ 	&0,
-  )
-`,
+		// TODO: This diff output is unhelpful and should show the address.
+		wantEqual: false,
 	}, {
 		label: label,
 		x: [2][]int{
@@ -635,18 +586,8 @@ func comparerTests() []test {
 				return false
 			}, cmp.Ignore()),
 		},
-		wantDiff: `
-  [2][]int{
-  	{..., 1, 2, 3, ..., 4, 5, 6, 7, ..., 8, ..., 9, ...},
-  	{
-  		... // 6 ignored and 1 identical elements
-- 		20,
-+ 		2,
-  		... // 3 ignored elements
-  	},
-  }
-`,
-		reason: "all zero slice elements are ignored (even if missing)",
+		wantEqual: false,
+		reason:    "all zero slice elements are ignored (even if missing)",
 	}, {
 		label: label,
 		x: [2]map[string]int{
@@ -669,17 +610,8 @@ func comparerTests() []test {
 				return false
 			}, cmp.Ignore()),
 		},
-		wantDiff: `
-  [2]map[string]int{
-  	{"KEEP3": 3, "keep1": 1, "keep2": 2, ...},
-  	{
-  		... // 2 ignored entries
-  		"keep1": 1,
-+ 		"keep2": 2,
-  	},
-  }
-`,
-		reason: "all zero map entries are ignored (even if missing)",
+		wantEqual: false,
+		reason:    "all zero map entries are ignored (even if missing)",
 	}, {
 		label:     label,
 		x:         namedWithUnexported{},
@@ -724,12 +656,7 @@ func transformerTests() []test {
 			cmp.Transformer("λ", func(in uint16) uint32 { return uint32(in) }),
 			cmp.Transformer("λ", func(in uint32) uint64 { return uint64(in) }),
 		},
-		wantDiff: `
-  uint8(Inverse(λ, uint16(Inverse(λ, uint32(Inverse(λ, uint64(
-- 	0x00,
-+ 	0x01,
-  )))))))
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     0,
@@ -753,16 +680,7 @@ func transformerTests() []test {
 				cmp.Transformer("λ", func(in int) int64 { return int64(in) }),
 			),
 		},
-		wantDiff: `
-  []int{
-  	Inverse(λ, int64(0)),
-- 	Inverse(λ, int64(-5)),
-+ 	Inverse(λ, int64(3)),
-  	Inverse(λ, int64(0)),
-- 	Inverse(λ, int64(-1)),
-+ 	Inverse(λ, int64(-5)),
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     0,
@@ -775,12 +693,7 @@ func transformerTests() []test {
 				return float64(in)
 			}),
 		},
-		wantDiff: `
-  int(Inverse(λ, interface{}(
-- 	string("zero"),
-+ 	float64(1),
-  )))
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x: `{
@@ -819,33 +732,7 @@ func transformerTests() []test {
 				return m
 			}),
 		},
-		wantDiff: `
-  string(Inverse(ParseJSON, map[string]interface{}{
-  	"address": map[string]interface{}{
-- 		"city":          string("Los Angeles"),
-+ 		"city":          string("New York"),
-  		"postalCode":    string("10021-3100"),
-- 		"state":         string("CA"),
-+ 		"state":         string("NY"),
-  		"streetAddress": string("21 2nd Street"),
-  	},
-  	"age":       float64(25),
-  	"children":  []interface{}{},
-  	"firstName": string("John"),
-  	"isAlive":   bool(true),
-  	"lastName":  string("Smith"),
-  	"phoneNumbers": []interface{}{
-  		map[string]interface{}{
-- 			"number": string("212 555-4321"),
-+ 			"number": string("212 555-1234"),
-  			"type":   string("home"),
-  		},
-  		map[string]interface{}{"number": string("646 555-4567"), "type": string("office")},
-  		map[string]interface{}{"number": string("123 456-7890"), "type": string("mobile")},
-  	},
-+ 	"spouse": nil,
-  }))
-`,
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     StringBytes{String: "some\nmulti\nLine\nstring", Bytes: []byte("some\nmulti\nline\nbytes")},
@@ -854,29 +741,7 @@ func transformerTests() []test {
 			transformOnce("SplitString", func(s string) []string { return strings.Split(s, "\n") }),
 			transformOnce("SplitBytes", func(b []byte) [][]byte { return bytes.Split(b, []byte("\n")) }),
 		},
-		wantDiff: `
-  cmp_test.StringBytes{
-  	String: Inverse(SplitString, []string{
-  		"some",
-  		"multi",
-- 		"Line",
-+ 		"line",
-  		"string",
-  	}),
-  	Bytes: []uint8(Inverse(SplitBytes, [][]uint8{
-  		{0x73, 0x6f, 0x6d, 0x65},
-  		{0x6d, 0x75, 0x6c, 0x74, 0x69},
-  		{0x6c, 0x69, 0x6e, 0x65},
-  		{
-- 			0x62,
-+ 			0x42,
-  			0x79,
-  			0x74,
-  			... // 2 identical elements
-  		},
-  	})),
-  }
-`,
+		wantEqual: false,
 	}, {
 		x: "a\nb\nc\n",
 		y: "a\nb\nc\n",
@@ -928,51 +793,17 @@ func reporterTests() []test {
 	)
 
 	return []test{{
-		label: label,
-		x:     MyComposite{IntsA: []int8{11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
-		y:     MyComposite{IntsA: []int8{10, 11, 21, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	... // 3 identical fields
-  	BytesB: nil,
-  	BytesC: nil,
-  	IntsA: []int8{
-+ 		10,
-  		11,
-- 		12,
-+ 		21,
-  		13,
-  		14,
-  		... // 15 identical elements
-  	},
-  	IntsB: nil,
-  	IntsC: nil,
-  	... // 6 identical fields
-  }
-`,
-		reason: "unbatched diffing desired since few elements differ",
+		label:     label,
+		x:         MyComposite{IntsA: []int8{11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
+		y:         MyComposite{IntsA: []int8{10, 11, 21, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
+		wantEqual: false,
+		reason:    "unbatched diffing desired since few elements differ",
 	}, {
-		label: label,
-		x:     MyComposite{IntsA: []int8{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
-		y:     MyComposite{IntsA: []int8{12, 29, 13, 27, 22, 23, 17, 18, 19, 20, 21, 10, 26, 16, 25, 28, 11, 15, 24, 14}},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	... // 3 identical fields
-  	BytesB: nil,
-  	BytesC: nil,
-  	IntsA: []int8{
-- 		10, 11, 12, 13, 14, 15, 16,
-+ 		12, 29, 13, 27, 22, 23,
-  		17, 18, 19, 20, 21,
-- 		22, 23, 24, 25, 26, 27, 28, 29,
-+ 		10, 26, 16, 25, 28, 11, 15, 24, 14,
-  	},
-  	IntsB: nil,
-  	IntsC: nil,
-  	... // 6 identical fields
-  }
-`,
-		reason: "batched diffing desired since many elements differ",
+		label:     label,
+		x:         MyComposite{IntsA: []int8{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29}},
+		y:         MyComposite{IntsA: []int8{12, 29, 13, 27, 22, 23, 17, 18, 19, 20, 21, 10, 26, 16, 25, 28, 11, 15, 24, 14}},
+		wantEqual: false,
+		reason:    "batched diffing desired since many elements differ",
 	}, {
 		label: label,
 		x: MyComposite{
@@ -1003,141 +834,26 @@ func reporterTests() []test {
 			FloatsB: []MyFloat{6.5, 5.5, 4.5},
 			FloatsC: MyFloats{9.5, 8.5, 7.5},
 		},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	StringA: "",
-  	StringB: "",
-  	BytesA: []uint8{
-- 		0x01, 0x02, 0x03, // -|...|
-+ 		0x03, 0x02, 0x01, // +|...|
-  	},
-  	BytesB: []cmp_test.MyByte{
-- 		0x04, 0x05, 0x06,
-+ 		0x06, 0x05, 0x04,
-  	},
-  	BytesC: cmp_test.MyBytes{
-- 		0x07, 0x08, 0x09, // -|...|
-+ 		0x09, 0x08, 0x07, // +|...|
-  	},
-  	IntsA: []int8{
-- 		-1, -2, -3,
-+ 		-3, -2, -1,
-  	},
-  	IntsB: []cmp_test.MyInt{
-- 		-4, -5, -6,
-+ 		-6, -5, -4,
-  	},
-  	IntsC: cmp_test.MyInts{
-- 		-7, -8, -9,
-+ 		-9, -8, -7,
-  	},
-  	UintsA: []uint16{
-- 		0x03e8, 0x07d0, 0x0bb8,
-+ 		0x0bb8, 0x07d0, 0x03e8,
-  	},
-  	UintsB: []cmp_test.MyUint{
-- 		4000, 5000, 6000,
-+ 		6000, 5000, 4000,
-  	},
-  	UintsC: cmp_test.MyUints{
-- 		7000, 8000, 9000,
-+ 		9000, 8000, 7000,
-  	},
-  	FloatsA: []float32{
-- 		1.5, 2.5, 3.5,
-+ 		3.5, 2.5, 1.5,
-  	},
-  	FloatsB: []cmp_test.MyFloat{
-- 		4.5, 5.5, 6.5,
-+ 		6.5, 5.5, 4.5,
-  	},
-  	FloatsC: cmp_test.MyFloats{
-- 		7.5, 8.5, 9.5,
-+ 		9.5, 8.5, 7.5,
-  	},
-  }
-`,
-		reason: "batched diffing available for both named and unnamed slices",
+		wantEqual: false,
+		reason:    "batched diffing available for both named and unnamed slices",
 	}, {
-		label: label,
-		x:     MyComposite{BytesA: []byte("\xf3\x0f\x8a\xa4\xd3\x12R\t$\xbeX\x95A\xfd$fX\x8byT\xac\r\xd8qwp\x20j\\s\u007f\x8c\x17U\xc04\xcen\xf7\xaaG\xee2\x9d\xc5\xca\x1eX\xaf\x8f'\xf3\x02J\x90\xedi.p2\xb4\xab0 \xb6\xbd\\b4\x17\xb0\x00\xbbO~'G\x06\xf4.f\xfdc\xd7\x04ݷ0\xb7\xd1U~{\xf6\xb3~\x1dWi \x9e\xbc\xdf\xe1M\xa9\xef\xa2\xd2\xed\xb4Gx\xc9\xc9'\xa4\xc6\xce\xecDp]")},
-		y:     MyComposite{BytesA: []byte("\xf3\x0f\x8a\xa4\xd3\x12R\t$\xbeT\xac\r\xd8qwp\x20j\\s\u007f\x8c\x17U\xc04\xcen\xf7\xaaG\xee2\x9d\xc5\xca\x1eX\xaf\x8f'\xf3\x02J\x90\xedi.p2\xb4\xab0 \xb6\xbd\\b4\x17\xb0\x00\xbbO~'G\x06\xf4.f\xfdc\xd7\x04ݷ0\xb7\xd1u-[]]\xf6\xb3haha~\x1dWI \x9e\xbc\xdf\xe1M\xa9\xef\xa2\xd2\xed\xb4Gx\xc9\xc9'\xa4\xc6\xce\xecDp]")},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	StringA: "",
-  	StringB: "",
-  	BytesA: []uint8{
-  		0xf3, 0x0f, 0x8a, 0xa4, 0xd3, 0x12, 0x52, 0x09, 0x24, 0xbe,                                     //  |......R.$.|
-- 		0x58, 0x95, 0x41, 0xfd, 0x24, 0x66, 0x58, 0x8b, 0x79,                                           // -|X.A.$fX.y|
-  		0x54, 0xac, 0x0d, 0xd8, 0x71, 0x77, 0x70, 0x20, 0x6a, 0x5c, 0x73, 0x7f, 0x8c, 0x17, 0x55, 0xc0, //  |T...qwp j\s...U.|
-  		0x34, 0xce, 0x6e, 0xf7, 0xaa, 0x47, 0xee, 0x32, 0x9d, 0xc5, 0xca, 0x1e, 0x58, 0xaf, 0x8f, 0x27, //  |4.n..G.2....X..'|
-  		0xf3, 0x02, 0x4a, 0x90, 0xed, 0x69, 0x2e, 0x70, 0x32, 0xb4, 0xab, 0x30, 0x20, 0xb6, 0xbd, 0x5c, //  |..J..i.p2..0 ..\|
-  		0x62, 0x34, 0x17, 0xb0, 0x00, 0xbb, 0x4f, 0x7e, 0x27, 0x47, 0x06, 0xf4, 0x2e, 0x66, 0xfd, 0x63, //  |b4....O~'G...f.c|
-  		0xd7, 0x04, 0xdd, 0xb7, 0x30, 0xb7, 0xd1,                                                       //  |....0..|
-- 		0x55, 0x7e, 0x7b, 0xf6, 0xb3, 0x7e, 0x1d, 0x57, 0x69,                                           // -|U~{..~.Wi|
-+ 		0x75, 0x2d, 0x5b, 0x5d, 0x5d, 0xf6, 0xb3, 0x68, 0x61, 0x68, 0x61, 0x7e, 0x1d, 0x57, 0x49,       // +|u-[]]..haha~.WI|
-  		0x20, 0x9e, 0xbc, 0xdf, 0xe1, 0x4d, 0xa9, 0xef, 0xa2, 0xd2, 0xed, 0xb4, 0x47, 0x78, 0xc9, 0xc9, //  | ....M......Gx..|
-  		0x27, 0xa4, 0xc6, 0xce, 0xec, 0x44, 0x70, 0x5d,                                                 //  |'....Dp]|
-  	},
-  	BytesB: nil,
-  	BytesC: nil,
-  	... // 9 identical fields
-  }
-`,
-		reason: "binary diff in hexdump form since data is binary data",
+		label:     label,
+		x:         MyComposite{BytesA: []byte("\xf3\x0f\x8a\xa4\xd3\x12R\t$\xbeX\x95A\xfd$fX\x8byT\xac\r\xd8qwp\x20j\\s\u007f\x8c\x17U\xc04\xcen\xf7\xaaG\xee2\x9d\xc5\xca\x1eX\xaf\x8f'\xf3\x02J\x90\xedi.p2\xb4\xab0 \xb6\xbd\\b4\x17\xb0\x00\xbbO~'G\x06\xf4.f\xfdc\xd7\x04ݷ0\xb7\xd1U~{\xf6\xb3~\x1dWi \x9e\xbc\xdf\xe1M\xa9\xef\xa2\xd2\xed\xb4Gx\xc9\xc9'\xa4\xc6\xce\xecDp]")},
+		y:         MyComposite{BytesA: []byte("\xf3\x0f\x8a\xa4\xd3\x12R\t$\xbeT\xac\r\xd8qwp\x20j\\s\u007f\x8c\x17U\xc04\xcen\xf7\xaaG\xee2\x9d\xc5\xca\x1eX\xaf\x8f'\xf3\x02J\x90\xedi.p2\xb4\xab0 \xb6\xbd\\b4\x17\xb0\x00\xbbO~'G\x06\xf4.f\xfdc\xd7\x04ݷ0\xb7\xd1u-[]]\xf6\xb3haha~\x1dWI \x9e\xbc\xdf\xe1M\xa9\xef\xa2\xd2\xed\xb4Gx\xc9\xc9'\xa4\xc6\xce\xecDp]")},
+		wantEqual: false,
+		reason:    "binary diff in hexdump form since data is binary data",
 	}, {
-		label: label,
-		x:     MyComposite{StringB: MyString("readme.txt\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000600\x000000000\x000000000\x0000000000046\x0000000000000\x00011173\x00 0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ustar\x0000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000000\x000000000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")},
-		y:     MyComposite{StringB: MyString("gopher.txt\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000600\x000000000\x000000000\x0000000000043\x0000000000000\x00011217\x00 0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ustar\x0000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000000\x000000000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	StringA: "",
-  	StringB: cmp_test.MyString{
-- 		0x72, 0x65, 0x61, 0x64, 0x6d, 0x65,                                                             // -|readme|
-+ 		0x67, 0x6f, 0x70, 0x68, 0x65, 0x72,                                                             // +|gopher|
-  		0x2e, 0x74, 0x78, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |.txt............|
-  		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |................|
-  		... // 64 identical bytes
-  		0x30, 0x30, 0x36, 0x30, 0x30, 0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x30, //  |00600.0000000.00|
-  		0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, //  |00000.0000000004|
-- 		0x36,                                                                                           // -|6|
-+ 		0x33,                                                                                           // +|3|
-  		0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x31, 0x31, //  |.00000000000.011|
-- 		0x31, 0x37, 0x33,                                                                               // -|173|
-+ 		0x32, 0x31, 0x37,                                                                               // +|217|
-  		0x00, 0x20, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |. 0.............|
-  		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |................|
-  		... // 326 identical bytes
-  	},
-  	BytesA: nil,
-  	BytesB: nil,
-  	... // 10 identical fields
-  }
-`,
-		reason: "binary diff desired since string looks like binary data",
+		label:     label,
+		x:         MyComposite{StringB: MyString("readme.txt\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000600\x000000000\x000000000\x0000000000046\x0000000000000\x00011173\x00 0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ustar\x0000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000000\x000000000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")},
+		y:         MyComposite{StringB: MyString("gopher.txt\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000600\x000000000\x000000000\x0000000000043\x0000000000000\x00011217\x00 0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ustar\x0000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x000000000\x000000000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")},
+		wantEqual: false,
+		reason:    "binary diff desired since string looks like binary data",
 	}, {
-		label: label,
-		x:     MyComposite{BytesA: []byte(`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"address":{"streetAddress":"314 54th Avenue","city":"New York","state":"NY","postalCode":"10021-3100"},"phoneNumbers":[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"},{"type":"mobile","number":"123 456-7890"}],"children":[],"spouse":null}`)},
-		y:     MyComposite{BytesA: []byte(`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"address":{"streetAddress":"21 2nd Street","city":"New York","state":"NY","postalCode":"10021-3100"},"phoneNumbers":[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"},{"type":"mobile","number":"123 456-7890"}],"children":[],"spouse":null}`)},
-		wantDiff: strings.Replace(`
-  cmp_test.MyComposite{
-  	StringA: "",
-  	StringB: "",
-  	BytesA: bytes.Join({
-  		'{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"',
-  		'address":{"streetAddress":"',
-- 		"314 54th Avenue",
-+ 		"21 2nd Street",
-  		'","city":"New York","state":"NY","postalCode":"10021-3100"},"pho',
-  		'neNumbers":[{"type":"home","number":"212 555-1234"},{"type":"off',
-  		... // 101 identical bytes
-  	}, ""),
-  	BytesB: nil,
-  	BytesC: nil,
-  	... // 9 identical fields
-  }
-`, "'", "`", -1),
-		reason: "batched textual diff desired since bytes looks like textual data",
+		label:     label,
+		x:         MyComposite{BytesA: []byte(`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"address":{"streetAddress":"314 54th Avenue","city":"New York","state":"NY","postalCode":"10021-3100"},"phoneNumbers":[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"},{"type":"mobile","number":"123 456-7890"}],"children":[],"spouse":null}`)},
+		y:         MyComposite{BytesA: []byte(`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"address":{"streetAddress":"21 2nd Street","city":"New York","state":"NY","postalCode":"10021-3100"},"phoneNumbers":[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"},{"type":"mobile","number":"123 456-7890"}],"children":[],"spouse":null}`)},
+		wantEqual: false,
+		reason:    "batched textual diff desired since bytes looks like textual data",
 	}, {
 		label: label,
 		x: MyComposite{
@@ -1187,33 +903,8 @@ fields are not compared by default; they result in panics unless suppressed
 by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly compared
 using the AllowUnexported option.`, "\n"),
 		},
-		wantDiff: `
-  cmp_test.MyComposite{
-  	StringA: strings.Join({
-- 		"Package cmp determines equality of values.",
-+ 		"Package cmp determines equality of value.",
-  		"",
-  		"This package is intended to be a more powerful and safer alternative to",
-  		... // 6 identical lines
-  		"For example, an equality function may report floats as equal so long as they",
-  		"are within some tolerance of each other.",
-- 		"",
-- 		"• Types that have an Equal method may use that method to determine equality.",
-- 		"This allows package authors to determine the equality operation for the types",
-- 		"that they define.",
-  		"",
-  		"• If no custom equality functions are used and no Equal method is defined,",
-  		... // 3 identical lines
-  		"by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly compared",
-  		"using the AllowUnexported option.",
-- 		"",
-  	}, "\n"),
-  	StringB: "",
-  	BytesA:  nil,
-  	... // 11 identical fields
-  }
-`,
-		reason: "batched per-line diff desired since string looks like multi-line textual data",
+		wantEqual: false,
+		reason:    "batched per-line diff desired since string looks like multi-line textual data",
 	}}
 }
 
@@ -1330,6 +1021,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructA{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructA",
 		x:     createStructA(0),
@@ -1345,6 +1037,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructA{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructA",
 		x:     createStructA(0),
@@ -1352,16 +1045,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructA{}, privateStruct),
 		},
-		wantDiff: `
-  teststructs.ParentStructA{
-  	privateStruct: teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label + "ParentStructB",
 		x:     ts.ParentStructB{},
@@ -1378,6 +1062,7 @@ func embeddedTests() []test {
 			cmpopts.IgnoreUnexported(ts.ParentStructB{}),
 			cmpopts.IgnoreUnexported(ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructB",
 		x:     createStructB(0),
@@ -1393,6 +1078,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructB{}, ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructB",
 		x:     createStructB(0),
@@ -1400,16 +1086,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructB{}, ts.PublicStruct{}),
 		},
-		wantDiff: `
-  teststructs.ParentStructB{
-  	PublicStruct: teststructs.PublicStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		label:     label + "ParentStructC",
 		x:         ts.ParentStructC{},
@@ -1422,6 +1099,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructC{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructC",
 		x:     createStructC(0),
@@ -1437,6 +1115,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructC{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructC",
 		x:     createStructC(0),
@@ -1444,20 +1123,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructC{}, privateStruct),
 		},
-		wantDiff: `
-  teststructs.ParentStructC{
-  	privateStruct: teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-- 	Public:  3,
-+ 	Public:  4,
-- 	private: 4,
-+ 	private: 5,
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label + "ParentStructD",
 		x:     ts.ParentStructD{},
@@ -1474,6 +1140,7 @@ func embeddedTests() []test {
 			cmpopts.IgnoreUnexported(ts.ParentStructD{}),
 			cmpopts.IgnoreUnexported(ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructD",
 		x:     createStructD(0),
@@ -1489,6 +1156,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructD{}, ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructD",
 		x:     createStructD(0),
@@ -1496,20 +1164,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructD{}, ts.PublicStruct{}),
 		},
-		wantDiff: `
-  teststructs.ParentStructD{
-  	PublicStruct: teststructs.PublicStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-- 	Public:  3,
-+ 	Public:  4,
-- 	private: 4,
-+ 	private: 5,
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label + "ParentStructE",
 		x:     ts.ParentStructE{},
@@ -1526,6 +1181,7 @@ func embeddedTests() []test {
 			cmpopts.IgnoreUnexported(ts.ParentStructE{}),
 			cmpopts.IgnoreUnexported(ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructE",
 		x:     createStructE(0),
@@ -1549,6 +1205,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructE{}, ts.PublicStruct{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructE",
 		x:     createStructE(0),
@@ -1556,22 +1213,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructE{}, ts.PublicStruct{}, privateStruct),
 		},
-		wantDiff: `
-  teststructs.ParentStructE{
-  	privateStruct: teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  	PublicStruct: teststructs.PublicStruct{
-- 		Public:  3,
-+ 		Public:  4,
-- 		private: 4,
-+ 		private: 5,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		label: label + "ParentStructF",
 		x:     ts.ParentStructF{},
@@ -1588,6 +1230,7 @@ func embeddedTests() []test {
 			cmpopts.IgnoreUnexported(ts.ParentStructF{}),
 			cmpopts.IgnoreUnexported(ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructF",
 		x:     createStructF(0),
@@ -1611,6 +1254,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructF{}, ts.PublicStruct{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructF",
 		x:     createStructF(0),
@@ -1618,31 +1262,13 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructF{}, ts.PublicStruct{}, privateStruct),
 		},
-		wantDiff: `
-  teststructs.ParentStructF{
-  	privateStruct: teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  	PublicStruct: teststructs.PublicStruct{
-- 		Public:  3,
-+ 		Public:  4,
-- 		private: 4,
-+ 		private: 5,
-  	},
-- 	Public:  5,
-+ 	Public:  6,
-- 	private: 6,
-+ 	private: 7,
-  }
-`,
+		wantEqual: false,
 	}, {
 		label:     label + "ParentStructG",
 		x:         ts.ParentStructG{},
 		y:         ts.ParentStructG{},
 		wantPanic: wantPanicNotGo110("cannot handle unexported field"),
+		wantEqual: !flags.AtLeastGo110,
 	}, {
 		label: label + "ParentStructG",
 		x:     ts.ParentStructG{},
@@ -1650,6 +1276,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructG{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructG",
 		x:     createStructG(0),
@@ -1665,6 +1292,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructG{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructG",
 		x:     createStructG(0),
@@ -1672,20 +1300,12 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructG{}, privateStruct),
 		},
-		wantDiff: `
-  &teststructs.ParentStructG{
-  	privateStruct: &teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
-		label: label + "ParentStructH",
-		x:     ts.ParentStructH{},
-		y:     ts.ParentStructH{},
+		label:     label + "ParentStructH",
+		x:         ts.ParentStructH{},
+		y:         ts.ParentStructH{},
+		wantEqual: true,
 	}, {
 		label:     label + "ParentStructH",
 		x:         createStructH(0),
@@ -1698,6 +1318,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructH{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructH",
 		x:     createStructH(0),
@@ -1713,6 +1334,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructH{}, ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructH",
 		x:     createStructH(0),
@@ -1720,21 +1342,13 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructH{}, ts.PublicStruct{}),
 		},
-		wantDiff: `
-  &teststructs.ParentStructH{
-  	PublicStruct: &teststructs.PublicStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		label:     label + "ParentStructI",
 		x:         ts.ParentStructI{},
 		y:         ts.ParentStructI{},
 		wantPanic: wantPanicNotGo110("cannot handle unexported field"),
+		wantEqual: !flags.AtLeastGo110,
 	}, {
 		label: label + "ParentStructI",
 		x:     ts.ParentStructI{},
@@ -1742,6 +1356,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructI{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructI",
 		x:     createStructI(0),
@@ -1757,6 +1372,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructI{}, ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructI",
 		x:     createStructI(0),
@@ -1772,6 +1388,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructI{}, ts.PublicStruct{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructI",
 		x:     createStructI(0),
@@ -1779,22 +1396,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructI{}, ts.PublicStruct{}, privateStruct),
 		},
-		wantDiff: `
-  &teststructs.ParentStructI{
-  	privateStruct: &teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  	PublicStruct: &teststructs.PublicStruct{
-- 		Public:  3,
-+ 		Public:  4,
-- 		private: 4,
-+ 		private: 5,
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		label:     label + "ParentStructJ",
 		x:         ts.ParentStructJ{},
@@ -1815,6 +1417,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmpopts.IgnoreUnexported(ts.ParentStructJ{}, ts.PublicStruct{}),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructJ",
 		x:     createStructJ(0),
@@ -1830,6 +1433,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructJ{}, ts.PublicStruct{}, privateStruct),
 		},
+		wantEqual: true,
 	}, {
 		label: label + "ParentStructJ",
 		x:     createStructJ(0),
@@ -1837,34 +1441,7 @@ func embeddedTests() []test {
 		opts: []cmp.Option{
 			cmp.AllowUnexported(ts.ParentStructJ{}, ts.PublicStruct{}, privateStruct),
 		},
-		wantDiff: `
-  &teststructs.ParentStructJ{
-  	privateStruct: &teststructs.privateStruct{
-- 		Public:  1,
-+ 		Public:  2,
-- 		private: 2,
-+ 		private: 3,
-  	},
-  	PublicStruct: &teststructs.PublicStruct{
-- 		Public:  3,
-+ 		Public:  4,
-- 		private: 4,
-+ 		private: 5,
-  	},
-  	Public: teststructs.PublicStruct{
-- 		Public:  7,
-+ 		Public:  8,
-- 		private: 8,
-+ 		private: 9,
-  	},
-  	private: teststructs.privateStruct{
-- 		Public:  5,
-+ 		Public:  6,
-- 		private: 6,
-+ 		private: 7,
-  	},
-  }
-`,
+		wantEqual: false,
 	}}
 }
 
@@ -1899,340 +1476,284 @@ func methodTests() []test {
 	// returns true, while the underlying data are fundamentally different.
 	// Since the method should be called, these are expected to be equal.
 	return []test{{
-		label: label + "StructA",
-		x:     ts.StructA{X: "NotEqual"},
-		y:     ts.StructA{X: "not_equal"},
+		label:     label + "StructA",
+		x:         ts.StructA{X: "NotEqual"},
+		y:         ts.StructA{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA",
-		x:     &ts.StructA{X: "NotEqual"},
-		y:     &ts.StructA{X: "not_equal"},
+		label:     label + "StructA",
+		x:         &ts.StructA{X: "NotEqual"},
+		y:         &ts.StructA{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructB",
-		x:     ts.StructB{X: "NotEqual"},
-		y:     ts.StructB{X: "not_equal"},
-		wantDiff: `
-  teststructs.StructB{
-- 	X: "NotEqual",
-+ 	X: "not_equal",
-  }
-`,
+		label:     label + "StructB",
+		x:         ts.StructB{X: "NotEqual"},
+		y:         ts.StructB{X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructB",
-		x:     ts.StructB{X: "NotEqual"},
-		y:     ts.StructB{X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructB",
+		x:         ts.StructB{X: "NotEqual"},
+		y:         ts.StructB{X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructB",
-		x:     &ts.StructB{X: "NotEqual"},
-		y:     &ts.StructB{X: "not_equal"},
+		label:     label + "StructB",
+		x:         &ts.StructB{X: "NotEqual"},
+		y:         &ts.StructB{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructC",
-		x:     ts.StructC{X: "NotEqual"},
-		y:     ts.StructC{X: "not_equal"},
+		label:     label + "StructC",
+		x:         ts.StructC{X: "NotEqual"},
+		y:         ts.StructC{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructC",
-		x:     &ts.StructC{X: "NotEqual"},
-		y:     &ts.StructC{X: "not_equal"},
+		label:     label + "StructC",
+		x:         &ts.StructC{X: "NotEqual"},
+		y:         &ts.StructC{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructD",
-		x:     ts.StructD{X: "NotEqual"},
-		y:     ts.StructD{X: "not_equal"},
-		wantDiff: `
-  teststructs.StructD{
-- 	X: "NotEqual",
-+ 	X: "not_equal",
-  }
-`,
+		label:     label + "StructD",
+		x:         ts.StructD{X: "NotEqual"},
+		y:         ts.StructD{X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructD",
-		x:     ts.StructD{X: "NotEqual"},
-		y:     ts.StructD{X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructD",
+		x:         ts.StructD{X: "NotEqual"},
+		y:         ts.StructD{X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructD",
-		x:     &ts.StructD{X: "NotEqual"},
-		y:     &ts.StructD{X: "not_equal"},
+		label:     label + "StructD",
+		x:         &ts.StructD{X: "NotEqual"},
+		y:         &ts.StructD{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructE",
-		x:     ts.StructE{X: "NotEqual"},
-		y:     ts.StructE{X: "not_equal"},
-		wantDiff: `
-  teststructs.StructE{
-- 	X: "NotEqual",
-+ 	X: "not_equal",
-  }
-`,
+		label:     label + "StructE",
+		x:         ts.StructE{X: "NotEqual"},
+		y:         ts.StructE{X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructE",
-		x:     ts.StructE{X: "NotEqual"},
-		y:     ts.StructE{X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructE",
+		x:         ts.StructE{X: "NotEqual"},
+		y:         ts.StructE{X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructE",
-		x:     &ts.StructE{X: "NotEqual"},
-		y:     &ts.StructE{X: "not_equal"},
+		label:     label + "StructE",
+		x:         &ts.StructE{X: "NotEqual"},
+		y:         &ts.StructE{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructF",
-		x:     ts.StructF{X: "NotEqual"},
-		y:     ts.StructF{X: "not_equal"},
-		wantDiff: `
-  teststructs.StructF{
-- 	X: "NotEqual",
-+ 	X: "not_equal",
-  }
-`,
+		label:     label + "StructF",
+		x:         ts.StructF{X: "NotEqual"},
+		y:         ts.StructF{X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructF",
-		x:     &ts.StructF{X: "NotEqual"},
-		y:     &ts.StructF{X: "not_equal"},
+		label:     label + "StructF",
+		x:         &ts.StructF{X: "NotEqual"},
+		y:         &ts.StructF{X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA1",
-		x:     ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "equal"},
-		y:     ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "equal"},
+		label:     label + "StructA1",
+		x:         ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "equal"},
+		y:         ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA1",
-		x:     ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructA1{
-  	StructA: teststructs.StructA{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructA1",
+		x:         ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructA1",
-		x:     &ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "equal"},
-		y:     &ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "equal"},
+		label:     label + "StructA1",
+		x:         &ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "equal"},
+		y:         &ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA1",
-		x:     &ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  &teststructs.StructA1{
-  	StructA: teststructs.StructA{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructA1",
+		x:         &ts.StructA1{StructA: ts.StructA{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructA1{StructA: ts.StructA{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructB1",
-		x:     ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "equal"},
-		y:     ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructB1",
+		x:         ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "equal"},
+		y:         ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructB1",
-		x:     ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
-		wantDiff: `
-  teststructs.StructB1{
-  	StructB: teststructs.StructB(Inverse(Ref, &teststructs.StructB{X: "NotEqual"})),
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructB1",
+		x:         ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: false,
 	}, {
-		label: label + "StructB1",
-		x:     &ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "equal"},
-		y:     &ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructB1",
+		x:         &ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "equal"},
+		y:         &ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructB1",
-		x:     &ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
-		wantDiff: `
-  &teststructs.StructB1{
-  	StructB: teststructs.StructB(Inverse(Ref, &teststructs.StructB{X: "NotEqual"})),
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructB1",
+		x:         &ts.StructB1{StructB: ts.StructB{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructB1{StructB: ts.StructB{X: "not_equal"}, X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: false,
 	}, {
-		label: label + "StructC1",
-		x:     ts.StructC1{StructC: ts.StructC{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructC1{StructC: ts.StructC{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructC1",
+		x:         ts.StructC1{StructC: ts.StructC{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructC1{StructC: ts.StructC{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructC1",
-		x:     &ts.StructC1{StructC: ts.StructC{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructC1{StructC: ts.StructC{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructC1",
+		x:         &ts.StructC1{StructC: ts.StructC{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructC1{StructC: ts.StructC{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructD1",
-		x:     ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructD1{
-- 	StructD: teststructs.StructD{X: "NotEqual"},
-+ 	StructD: teststructs.StructD{X: "not_equal"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructD1",
+		x:         ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructD1",
-		x:     ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructD1",
+		x:         ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructD1",
-		x:     &ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructD1",
+		x:         &ts.StructD1{StructD: ts.StructD{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructD1{StructD: ts.StructD{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructE1",
-		x:     ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructE1{
-- 	StructE: teststructs.StructE{X: "NotEqual"},
-+ 	StructE: teststructs.StructE{X: "not_equal"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructE1",
+		x:         ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructE1",
-		x:     ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
-		opts:  []cmp.Option{derefTransform},
+		label:     label + "StructE1",
+		x:         ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
+		opts:      []cmp.Option{derefTransform},
+		wantEqual: true,
 	}, {
-		label: label + "StructE1",
-		x:     &ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructE1",
+		x:         &ts.StructE1{StructE: ts.StructE{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructE1{StructE: ts.StructE{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructF1",
-		x:     ts.StructF1{StructF: ts.StructF{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructF1{StructF: ts.StructF{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructF1{
-- 	StructF: teststructs.StructF{X: "NotEqual"},
-+ 	StructF: teststructs.StructF{X: "not_equal"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructF1",
+		x:         ts.StructF1{StructF: ts.StructF{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructF1{StructF: ts.StructF{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructF1",
-		x:     &ts.StructF1{StructF: ts.StructF{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructF1{StructF: ts.StructF{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructF1",
+		x:         &ts.StructF1{StructF: ts.StructF{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructF1{StructF: ts.StructF{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA2",
-		x:     ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "equal"},
-		y:     ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "equal"},
+		label:     label + "StructA2",
+		x:         ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "equal"},
+		y:         ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA2",
-		x:     ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructA2{
-  	StructA: &teststructs.StructA{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructA2",
+		x:         ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructA2",
-		x:     &ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "equal"},
-		y:     &ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "equal"},
+		label:     label + "StructA2",
+		x:         &ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "equal"},
+		y:         &ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructA2",
-		x:     &ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  &teststructs.StructA2{
-  	StructA: &teststructs.StructA{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructA2",
+		x:         &ts.StructA2{StructA: &ts.StructA{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructA2{StructA: &ts.StructA{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructB2",
-		x:     ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "equal"},
-		y:     ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "equal"},
+		label:     label + "StructB2",
+		x:         ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "equal"},
+		y:         ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructB2",
-		x:     ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  teststructs.StructB2{
-  	StructB: &teststructs.StructB{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructB2",
+		x:         ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructB2",
-		x:     &ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "equal"},
-		y:     &ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "equal"},
+		label:     label + "StructB2",
+		x:         &ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "equal"},
+		y:         &ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructB2",
-		x:     &ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "not_equal"},
-		wantDiff: `
-  &teststructs.StructB2{
-  	StructB: &teststructs.StructB{X: "NotEqual"},
-- 	X:       "NotEqual",
-+ 	X:       "not_equal",
-  }
-`,
+		label:     label + "StructB2",
+		x:         &ts.StructB2{StructB: &ts.StructB{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructB2{StructB: &ts.StructB{X: "not_equal"}, X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "StructC2",
-		x:     ts.StructC2{StructC: &ts.StructC{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructC2{StructC: &ts.StructC{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructC2",
+		x:         ts.StructC2{StructC: &ts.StructC{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructC2{StructC: &ts.StructC{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructC2",
-		x:     &ts.StructC2{StructC: &ts.StructC{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructC2{StructC: &ts.StructC{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructC2",
+		x:         &ts.StructC2{StructC: &ts.StructC{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructC2{StructC: &ts.StructC{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructD2",
-		x:     ts.StructD2{StructD: &ts.StructD{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructD2{StructD: &ts.StructD{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructD2",
+		x:         ts.StructD2{StructD: &ts.StructD{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructD2{StructD: &ts.StructD{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructD2",
-		x:     &ts.StructD2{StructD: &ts.StructD{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructD2{StructD: &ts.StructD{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructD2",
+		x:         &ts.StructD2{StructD: &ts.StructD{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructD2{StructD: &ts.StructD{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructE2",
-		x:     ts.StructE2{StructE: &ts.StructE{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructE2{StructE: &ts.StructE{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructE2",
+		x:         ts.StructE2{StructE: &ts.StructE{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructE2{StructE: &ts.StructE{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructE2",
-		x:     &ts.StructE2{StructE: &ts.StructE{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructE2{StructE: &ts.StructE{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructE2",
+		x:         &ts.StructE2{StructE: &ts.StructE{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructE2{StructE: &ts.StructE{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructF2",
-		x:     ts.StructF2{StructF: &ts.StructF{X: "NotEqual"}, X: "NotEqual"},
-		y:     ts.StructF2{StructF: &ts.StructF{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructF2",
+		x:         ts.StructF2{StructF: &ts.StructF{X: "NotEqual"}, X: "NotEqual"},
+		y:         ts.StructF2{StructF: &ts.StructF{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructF2",
-		x:     &ts.StructF2{StructF: &ts.StructF{X: "NotEqual"}, X: "NotEqual"},
-		y:     &ts.StructF2{StructF: &ts.StructF{X: "not_equal"}, X: "not_equal"},
+		label:     label + "StructF2",
+		x:         &ts.StructF2{StructF: &ts.StructF{X: "NotEqual"}, X: "NotEqual"},
+		y:         &ts.StructF2{StructF: &ts.StructF{X: "not_equal"}, X: "not_equal"},
+		wantEqual: true,
 	}, {
-		label: label + "StructNo",
-		x:     ts.StructNo{X: "NotEqual"},
-		y:     ts.StructNo{X: "not_equal"},
-		wantDiff: `
-  teststructs.StructNo{
-- 	X: "NotEqual",
-+ 	X: "not_equal",
-  }
-`,
+		label:     label + "StructNo",
+		x:         ts.StructNo{X: "NotEqual"},
+		y:         ts.StructNo{X: "not_equal"},
+		wantEqual: false,
 	}, {
-		label: label + "AssignA",
-		x:     ts.AssignA(func() int { return 0 }),
-		y:     ts.AssignA(func() int { return 1 }),
+		label:     label + "AssignA",
+		x:         ts.AssignA(func() int { return 0 }),
+		y:         ts.AssignA(func() int { return 1 }),
+		wantEqual: true,
 	}, {
-		label: label + "AssignB",
-		x:     ts.AssignB(struct{ A int }{0}),
-		y:     ts.AssignB(struct{ A int }{1}),
+		label:     label + "AssignB",
+		x:         ts.AssignB(struct{ A int }{0}),
+		y:         ts.AssignB(struct{ A int }{1}),
+		wantEqual: true,
 	}, {
-		label: label + "AssignC",
-		x:     ts.AssignC(make(chan bool)),
-		y:     ts.AssignC(make(chan bool)),
+		label:     label + "AssignC",
+		x:         ts.AssignC(make(chan bool)),
+		y:         ts.AssignC(make(chan bool)),
+		wantEqual: true,
 	}, {
-		label: label + "AssignD",
-		x:     ts.AssignD(make(chan bool)),
-		y:     ts.AssignD(make(chan bool)),
+		label:     label + "AssignD",
+		x:         ts.AssignD(make(chan bool)),
+		y:         ts.AssignD(make(chan bool)),
+		wantEqual: true,
 	}}
 }
 
@@ -2317,9 +1838,9 @@ func cycleTests() []test {
 	var tests []test
 	type XY struct{ x, y interface{} }
 	for _, tt := range []struct {
-		in       XY
-		wantDiff string
-		reason   string
+		in        XY
+		wantEqual bool
+		reason    string
 	}{{
 		in: func() XY {
 			x := new(P)
@@ -2328,6 +1849,7 @@ func cycleTests() []test {
 			*y = y
 			return XY{x, y}
 		}(),
+		wantEqual: true,
 	}, {
 		in: func() XY {
 			x := new(P)
@@ -2337,12 +1859,7 @@ func cycleTests() []test {
 			*y2 = y1
 			return XY{x, y1}
 		}(),
-		wantDiff: `
-  &&cmp_test.P(
-- 	&⟪0xdeadf00f⟫,
-+ 	&&⟪0xdeadf00f⟫,
-  )
-`,
+		wantEqual: false,
 	}, {
 		in: func() XY {
 			x := S{nil}
@@ -2351,6 +1868,7 @@ func cycleTests() []test {
 			y[0] = y
 			return XY{x, y}
 		}(),
+		wantEqual: true,
 	}, {
 		in: func() XY {
 			x := S{nil}
@@ -2360,12 +1878,7 @@ func cycleTests() []test {
 			y2[0] = y1
 			return XY{x, y1}
 		}(),
-		wantDiff: `
-  cmp_test.S{
-- 	{{{*(*cmp_test.S)(⟪0xdeadf00f⟫)}}},
-+ 	{{{{*(*cmp_test.S)(⟪0xdeadf00f⟫)}}}},
-  }
-`,
+		wantEqual: false,
 	}, {
 		in: func() XY {
 			x := M{0: nil}
@@ -2374,6 +1887,7 @@ func cycleTests() []test {
 			y[0] = y
 			return XY{x, y}
 		}(),
+		wantEqual: true,
 	}, {
 		in: func() XY {
 			x := M{0: nil}
@@ -2383,14 +1897,10 @@ func cycleTests() []test {
 			y2[0] = y1
 			return XY{x, y1}
 		}(),
-		wantDiff: `
-  cmp_test.M{
-- 	0: {0: ⟪0xdeadf00f⟫},
-+ 	0: {0: {0: ⟪0xdeadf00f⟫}},
-  }
-`,
+		wantEqual: false,
 	}, {
-		in: XY{makeGraph(), makeGraph()},
+		in:        XY{makeGraph(), makeGraph()},
+		wantEqual: true,
 	}, {
 		in: func() XY {
 			x := makeGraph()
@@ -2400,120 +1910,7 @@ func cycleTests() []test {
 			y["Bar"].Bravos["BuzzBarBravo"].ID = 0
 			return XY{x, y}
 		}(),
-		wantDiff: `
-  map[string]*cmp_test.CycleAlpha{
-  	"Bar": &{
-  		Name: "Bar",
-  		Bravos: map[string]*cmp_test.CycleBravo{
-  			"BarBuzzBravo": &{
-- 				ID:   102,
-+ 				ID:   0,
-  				Name: "BarBuzzBravo",
-  				Mods: 2,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  					"Buzz": &{
-  						Name: "Buzz",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
-  							"BuzzBarBravo": &{
-- 								ID:     103,
-+ 								ID:     0,
-  								Name:   "BuzzBarBravo",
-  								Mods:   0,
-  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"BuzzBarBravo": &{
-- 				ID:   103,
-+ 				ID:   0,
-  				Name: "BuzzBarBravo",
-  				Mods: 0,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  					"Buzz": &{
-  						Name: "Buzz",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{
-- 								ID:     102,
-+ 								ID:     0,
-  								Name:   "BarBuzzBravo",
-  								Mods:   2,
-  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
-  							},
-  							"BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": ⟪0xdeadf00f⟫}},
-  						},
-  					},
-  				},
-  			},
-  		},
-  	},
-  	"Buzz": &{
-  		Name: "Buzz",
-  		Bravos: map[string]*cmp_test.CycleBravo{
-  			"BarBuzzBravo": &{
-- 				ID:   102,
-+ 				ID:   0,
-  				Name: "BarBuzzBravo",
-  				Mods: 2,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{
-  						Name: "Bar",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
-  							"BuzzBarBravo": &{
-- 								ID:     103,
-+ 								ID:     0,
-  								Name:   "BuzzBarBravo",
-  								Mods:   0,
-  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
-  							},
-  						},
-  					},
-  					"Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  				},
-  			},
-  			"BuzzBarBravo": &{
-- 				ID:   103,
-+ 				ID:   0,
-  				Name: "BuzzBarBravo",
-  				Mods: 0,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{
-  						Name: "Bar",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{
-- 								ID:     102,
-+ 								ID:     0,
-  								Name:   "BarBuzzBravo",
-  								Mods:   2,
-  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
-  							},
-  							"BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": ⟪0xdeadf00f⟫}},
-  						},
-  					},
-  					"Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  				},
-  			},
-  		},
-  	},
-  	"Foo": &{
-  		Name: "Foo",
-  		Bravos: map[string]*cmp_test.CycleBravo{
-  			"FooBravo": &{
-- 				ID:     101,
-+ 				ID:     0,
-  				Name:   "FooBravo",
-  				Mods:   100,
-  				Alphas: map[string]*cmp_test.CycleAlpha{"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": ⟪0xdeadf00f⟫}}}}},
-  			},
-  		},
-  	},
-  }
-`,
+		wantEqual: false,
 	}, {
 		in: func() XY {
 			x := makeGraph()
@@ -2524,151 +1921,14 @@ func cycleTests() []test {
 			}
 			return XY{x, y}
 		}(),
-		wantDiff: `
-  map[string]*cmp_test.CycleAlpha{
-  	"Bar": &{
-  		Name: "Bar",
-  		Bravos: map[string]*cmp_test.CycleBravo{
-  			"BarBuzzBravo": &{
-  				ID:   102,
-  				Name: "BarBuzzBravo",
-  				Mods: 2,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  					"Buzz": &{
-  						Name: "Buzz",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
-  							"BuzzBarBravo": &{
-  								ID:     103,
-  								Name:   "BuzzBarBravo",
-  								Mods:   0,
-- 								Alphas: nil,
-+ 								Alphas: map[string]*cmp_test.CycleAlpha{
-+ 									"Bar": &{
-+ 										Name: "Bar",
-+ 										Bravos: map[string]*cmp_test.CycleBravo{
-+ 											"BarBuzzBravo": &{
-+ 												ID:   102,
-+ 												Name: "BarBuzzBravo",
-+ 												Mods: 2,
-+ 												Alphas: map[string]*cmp_test.CycleAlpha{
-+ 													"Bar": ⟪0xdeadf00f⟫,
-+ 													"Buzz": &{
-+ 														Name: "Buzz",
-+ 														Bravos: map[string]*cmp_test.CycleBravo{
-+ 															"BarBuzzBravo": ⟪0xdeadf00f⟫,
-+ 															"BuzzBarBravo": &{
-+ 																ID:     103,
-+ 																Name:   "BuzzBarBravo",
-+ 																Alphas: map[string]*cmp_test.CycleAlpha(⟪0xdeadf00f⟫),
-+ 															},
-+ 														},
-+ 													},
-+ 												},
-+ 											},
-+ 											"BuzzBarBravo": ⟪0xdeadf00f⟫,
-+ 										},
-+ 									},
-+ 									"Buzz": ⟪0xdeadf00f⟫,
-+ 								},
-  							},
-  						},
-  					},
-  				},
-  			},
-  			"BuzzBarBravo": &{
-  				ID:   103,
-  				Name: "BuzzBarBravo",
-  				Mods: 0,
-  				Alphas: map[string]*cmp_test.CycleAlpha{
-  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
-  					"Buzz": &{
-  						Name: "Buzz",
-  						Bravos: map[string]*cmp_test.CycleBravo{
-  							"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}},
-- 							"BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo"},
-+ 							"BuzzBarBravo": &{
-+ 								ID:   103,
-+ 								Name: "BuzzBarBravo",
-+ 								Alphas: map[string]*cmp_test.CycleAlpha{
-+ 									"Bar": &{
-+ 										Name: "Bar",
-+ 										Bravos: map[string]*cmp_test.CycleBravo{
-+ 											"BarBuzzBravo": &{
-+ 												ID:   102,
-+ 												Name: "BarBuzzBravo",
-+ 												Mods: 2,
-+ 												Alphas: map[string]*cmp_test.CycleAlpha{
-+ 													"Bar": ⟪0xdeadf00f⟫,
-+ 													"Buzz": &{
-+ 														Name:   "Buzz",
-+ 														Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫},
-+ 													},
-+ 												},
-+ 											},
-+ 											"BuzzBarBravo": ⟪0xdeadf00f⟫,
-+ 										},
-+ 									},
-+ 									"Buzz": ⟪0xdeadf00f⟫,
-+ 								},
-+ 							},
-  						},
-  					},
-  				},
-  			},
-  		},
-  	},
-  	"Buzz": &{
-  		Name: "Buzz",
-  		Bravos: map[string]*cmp_test.CycleBravo{
-  			"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}},
-  			"BuzzBarBravo": &{
-  				ID:     103,
-  				Name:   "BuzzBarBravo",
-  				Mods:   0,
-- 				Alphas: nil,
-+ 				Alphas: map[string]*cmp_test.CycleAlpha{
-+ 					"Bar": &{
-+ 						Name: "Bar",
-+ 						Bravos: map[string]*cmp_test.CycleBravo{
-+ 							"BarBuzzBravo": &{
-+ 								ID:   102,
-+ 								Name: "BarBuzzBravo",
-+ 								Mods: 2,
-+ 								Alphas: map[string]*cmp_test.CycleAlpha{
-+ 									"Bar": ⟪0xdeadf00f⟫,
-+ 									"Buzz": &{
-+ 										Name: "Buzz",
-+ 										Bravos: map[string]*cmp_test.CycleBravo{
-+ 											"BarBuzzBravo": ⟪0xdeadf00f⟫,
-+ 											"BuzzBarBravo": &{
-+ 												ID:     103,
-+ 												Name:   "BuzzBarBravo",
-+ 												Alphas: map[string]*cmp_test.CycleAlpha(⟪0xdeadf00f⟫),
-+ 											},
-+ 										},
-+ 									},
-+ 								},
-+ 							},
-+ 							"BuzzBarBravo": ⟪0xdeadf00f⟫,
-+ 						},
-+ 					},
-+ 					"Buzz": ⟪0xdeadf00f⟫,
-+ 				},
-  			},
-  		},
-  	},
-  	"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{ID: 101, Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{ID: 101, Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": ⟪0xdeadf00f⟫}}}}}}}},
-  }
-`,
+		wantEqual: false,
 	}} {
 		tests = append(tests, test{
-			label:    label,
-			x:        tt.in.x,
-			y:        tt.in.y,
-			wantDiff: tt.wantDiff,
-			reason:   tt.reason,
+			label:     label,
+			x:         tt.in.x,
+			y:         tt.in.y,
+			wantEqual: tt.wantEqual,
+			reason:    tt.reason,
 		})
 	}
 	return tests
@@ -2750,7 +2010,8 @@ func project1Tests() []test {
 		y: ts.Eagle{Slaps: []ts.Slap{{
 			Args: &pb.MetaData{Stringer: pb.Stringer{X: "metadata"}},
 		}}},
-		opts: []cmp.Option{cmp.Comparer(pb.Equal)},
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal)},
+		wantEqual: true,
 	}, {
 		label: label,
 		x: ts.Eagle{Slaps: []ts.Slap{{}, {}, {}, {}, {
@@ -2759,37 +2020,14 @@ func project1Tests() []test {
 		y: ts.Eagle{Slaps: []ts.Slap{{}, {}, {}, {}, {
 			Args: &pb.MetaData{Stringer: pb.Stringer{X: "metadata2"}},
 		}}},
-		opts: []cmp.Option{cmp.Comparer(pb.Equal)},
-		wantDiff: `
-  teststructs.Eagle{
-  	... // 4 identical fields
-  	Dreamers: nil,
-  	Prong:    0,
-  	Slaps: []teststructs.Slap{
-  		... // 2 identical elements
-  		{},
-  		{},
-  		{
-  			Name:     "",
-  			Desc:     "",
-  			DescLong: "",
-- 			Args:     s"metadata",
-+ 			Args:     s"metadata2",
-  			Tense:    0,
-  			Interval: 0,
-  			... // 3 identical fields
-  		},
-  	},
-  	StateGoverner: "",
-  	PrankRating:   "",
-  	... // 2 identical fields
-  }
-`,
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal)},
+		wantEqual: false,
 	}, {
-		label: label,
-		x:     createEagle(),
-		y:     createEagle(),
-		opts:  []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
+		label:     label,
+		x:         createEagle(),
+		y:         createEagle(),
+		opts:      []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
+		wantEqual: true,
 	}, {
 		label: label,
 		x: func() ts.Eagle {
@@ -2805,80 +2043,8 @@ func project1Tests() []test {
 			eg.Slaps[0].Immutable.LoveRadius.Summer.Summary.Devices = devs[:1]
 			return eg
 		}(),
-		opts: []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
-		wantDiff: `
-  teststructs.Eagle{
-  	... // 2 identical fields
-  	Desc:     "some description",
-  	DescLong: "",
-  	Dreamers: []teststructs.Dreamer{
-  		{},
-  		{
-  			... // 4 identical fields
-  			ContSlaps:         nil,
-  			ContSlapsInterval: 0,
-  			Animal: []interface{}{
-  				teststructs.Goat{
-  					Target:     "corporation",
-  					Slaps:      nil,
-  					FunnyPrank: "",
-  					Immutable: &teststructs.GoatImmutable{
-- 						ID:      "southbay2",
-+ 						ID:      "southbay",
-- 						State:   &6,
-+ 						State:   &5,
-  						Started: s"2009-11-10 23:00:00 +0000 UTC",
-  						Stopped: s"0001-01-01 00:00:00 +0000 UTC",
-  						... // 1 ignored and 1 identical fields
-  					},
-  				},
-  				teststructs.Donkey{},
-  			},
-  			Ornamental: false,
-  			Amoeba:     53,
-  			... // 5 identical fields
-  		},
-  	},
-  	Prong: 0,
-  	Slaps: []teststructs.Slap{
-  		{
-  			... // 6 identical fields
-  			Homeland:   0x00,
-  			FunnyPrank: "",
-  			Immutable: &teststructs.SlapImmutable{
-  				ID:          "immutableSlap",
-  				Out:         nil,
-- 				MildSlap:    false,
-+ 				MildSlap:    true,
-  				PrettyPrint: "",
-  				State:       nil,
-  				Started:     s"2009-11-10 23:00:00 +0000 UTC",
-  				Stopped:     s"0001-01-01 00:00:00 +0000 UTC",
-  				LastUpdate:  s"0001-01-01 00:00:00 +0000 UTC",
-  				LoveRadius: &teststructs.LoveRadius{
-  					Summer: &teststructs.SummerLove{
-  						Summary: &teststructs.SummerLoveSummary{
-  							Devices: []string{
-  								"foo",
-- 								"bar",
-- 								"baz",
-  							},
-  							ChangeType: []testprotos.SummerType{1, 2, 3},
-  							... // 1 ignored field
-  						},
-  						... // 1 ignored field
-  					},
-  					... // 1 ignored field
-  				},
-  				... // 1 ignored field
-  			},
-  		},
-  	},
-  	StateGoverner: "",
-  	PrankRating:   "",
-  	... // 2 identical fields
-  }
-`,
+		opts:      []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
+		wantEqual: false,
 	}}
 }
 
@@ -2943,10 +2109,11 @@ func project2Tests() []test {
 		y:         createBatch(),
 		wantPanic: "cannot handle unexported field",
 	}, {
-		label: label,
-		x:     createBatch(),
-		y:     createBatch(),
-		opts:  []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		label:     label,
+		x:         createBatch(),
+		y:         createBatch(),
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		wantEqual: true,
 	}, {
 		label: label,
 		x:     createBatch(),
@@ -2956,23 +2123,8 @@ func project2Tests() []test {
 			s[0], s[1], s[2] = s[1], s[2], s[0]
 			return gb
 		}(),
-		opts: []cmp.Option{cmp.Comparer(pb.Equal), equalDish},
-		wantDiff: `
-  teststructs.GermBatch{
-  	DirtyGerms: map[int32][]*testprotos.Germ{
-  		17: {s"germ1"},
-  		18: {
-- 			s"germ2",
-  			s"germ3",
-  			s"germ4",
-+ 			s"germ2",
-  		},
-  	},
-  	CleanGerms: nil,
-  	GermMap:    map[int32]*testprotos.Germ{13: s"germ13", 21: s"germ21"},
-  	... // 7 identical fields
-  }
-`,
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal), equalDish},
+		wantEqual: false,
 	}, {
 		label: label,
 		x:     createBatch(),
@@ -2982,7 +2134,8 @@ func project2Tests() []test {
 			s[0], s[1], s[2] = s[1], s[2], s[0]
 			return gb
 		}(),
-		opts: []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		wantEqual: true,
 	}, {
 		label: label,
 		x: func() ts.GermBatch {
@@ -2997,34 +2150,8 @@ func project2Tests() []test {
 			gb.GermStrain = 22
 			return gb
 		}(),
-		opts: []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
-		wantDiff: `
-  teststructs.GermBatch{
-  	DirtyGerms: map[int32][]*testprotos.Germ{
-+ 		17: {s"germ1"},
-  		18: Inverse(Sort, []*testprotos.Germ{
-  			s"germ2",
-  			s"germ3",
-- 			s"germ4",
-  		}),
-  	},
-  	CleanGerms: nil,
-  	GermMap:    map[int32]*testprotos.Germ{13: s"germ13", 21: s"germ21"},
-  	DishMap: map[int32]*teststructs.Dish{
-  		0: &{err: &errors.errorString{s: "EOF"}},
-- 		1: nil,
-+ 		1: &{err: &errors.errorString{s: "unexpected EOF"}},
-  		2: &{pb: &testprotos.Dish{Stringer: testprotos.Stringer{X: "dish"}}},
-  	},
-  	HasPreviousResult: true,
-  	DirtyID:           10,
-  	CleanID:           0,
-- 	GermStrain:        421,
-+ 	GermStrain:        22,
-  	TotalDirtyGerms:   0,
-  	InfectedAt:        s"2009-11-10 23:00:00 +0000 UTC",
-  }
-`,
+		opts:      []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		wantEqual: false,
 	}}
 }
 
@@ -3073,10 +2200,11 @@ func project3Tests() []test {
 		opts:      []cmp.Option{allowVisibility, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
 		wantPanic: "cannot handle unexported field",
 	}, {
-		label: label,
-		x:     createDirt(),
-		y:     createDirt(),
-		opts:  []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+		label:     label,
+		x:         createDirt(),
+		y:         createDirt(),
+		opts:      []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+		wantEqual: true,
 	}, {
 		label: label,
 		x: func() ts.Dirt {
@@ -3093,26 +2221,8 @@ func project3Tests() []test {
 			})
 			return d
 		}(),
-		opts: []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
-		wantDiff: `
-  teststructs.Dirt{
-- 	table:   &teststructs.MockTable{state: []string{"a", "c"}},
-+ 	table:   &teststructs.MockTable{state: []string{"a", "b", "c"}},
-  	ts:      12345,
-- 	Discord: 554,
-+ 	Discord: 500,
-- 	Proto:   testprotos.Dirt(Inverse(λ, s"blah")),
-+ 	Proto:   testprotos.Dirt(Inverse(λ, s"proto")),
-  	wizard: map[string]*testprotos.Wizard{
-- 		"albus": s"dumbledore",
-- 		"harry": s"potter",
-+ 		"harry": s"otter",
-  	},
-  	sadistic: nil,
-  	lastTime: 54321,
-  	... // 1 ignored field
-  }
-`,
+		opts:      []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+		wantEqual: false,
 	}}
 }
 
@@ -3166,10 +2276,11 @@ func project4Tests() []test {
 		opts:      []cmp.Option{allowVisibility, cmp.Comparer(pb.Equal)},
 		wantPanic: "cannot handle unexported field",
 	}, {
-		label: label,
-		x:     createCartel(),
-		y:     createCartel(),
-		opts:  []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
+		label:     label,
+		x:         createCartel(),
+		y:         createCartel(),
+		opts:      []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
+		wantEqual: true,
 	}, {
 		label: label,
 		x: func() ts.Cartel {
@@ -3189,49 +2300,8 @@ func project4Tests() []test {
 			d.SetPublicMessage([]byte{1, 2, 4, 3, 5})
 			return d
 		}(),
-		opts: []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
-		wantDiff: `
-  teststructs.Cartel{
-  	Headquarter: teststructs.Headquarter{
-  		id:       0x05,
-  		location: "moon",
-  		subDivisions: []string{
-- 			"alpha",
-  			"bravo",
-  			"charlie",
-  		},
-  		incorporatedDate: s"0001-01-01 00:00:00 +0000 UTC",
-  		metaData:         s"metadata",
-  		privateMessage:   nil,
-  		publicMessage: []uint8{
-  			0x01,
-  			0x02,
-- 			0x03,
-+ 			0x04,
-- 			0x04,
-+ 			0x03,
-  			0x05,
-  		},
-  		horseBack: "abcdef",
-  		rattle:    "",
-  		... // 5 identical fields
-  	},
-  	source:        "mars",
-  	creationDate:  s"0001-01-01 00:00:00 +0000 UTC",
-  	boss:          "al capone",
-  	lastCrimeDate: s"0001-01-01 00:00:00 +0000 UTC",
-  	poisons: []*teststructs.Poison{
-  		&{
-- 			poisonType:   1,
-+ 			poisonType:   5,
-  			expiration:   s"2009-11-10 23:00:00 +0000 UTC",
-  			manufacturer: "acme",
-  			potency:      0,
-  		},
-- 		&{poisonType: 2, manufacturer: "acme2"},
-  	},
-  }
-`,
+		opts:      []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
+		wantEqual: false,
 	}}
 }
 

--- a/cmp/testdata/diffs
+++ b/cmp/testdata/diffs
@@ -1,0 +1,1171 @@
+<<< TestDiff/Comparer#09
+  struct{ A int; B int; C int }{
+  	A: 1,
+  	B: 2,
+- 	C: 3,
++ 	C: 4,
+  }
+>>> TestDiff/Comparer#09
+<<< TestDiff/Comparer#12
+  &struct{ A *int }{
+- 	A: &4,
++ 	A: &5,
+  }
+>>> TestDiff/Comparer#12
+<<< TestDiff/Comparer#16
+  &struct{ R *bytes.Buffer }{
+- 	R: s"",
++ 	R: nil,
+  }
+>>> TestDiff/Comparer#16
+<<< TestDiff/Comparer#23
+  []*regexp.Regexp{
+  	nil,
+- 	s"a*b*c*",
++ 	s"a*b*d*",
+  }
+>>> TestDiff/Comparer#23
+<<< TestDiff/Comparer#25
+  &&&int(
+- 	0,
++ 	1,
+  )
+>>> TestDiff/Comparer#25
+<<< TestDiff/Comparer#28
+  struct{ fmt.Stringer }(
+- 	s"hello",
++ 	s"hello2",
+  )
+>>> TestDiff/Comparer#28
+<<< TestDiff/Comparer#29
+  [16]uint8{
+- 	0x0c, 0xc1, 0x75, 0xb9, 0xc0, 0xf1, 0xb6, 0xa8, 0x31, 0xc3, 0x99, 0xe2, 0x69, 0x77, 0x26, 0x61,
++ 	0x92, 0xeb, 0x5f, 0xfe, 0xe6, 0xae, 0x2f, 0xec, 0x3a, 0xd7, 0x1c, 0x77, 0x75, 0x31, 0x57, 0x8f,
+  }
+>>> TestDiff/Comparer#29
+<<< TestDiff/Comparer#30
+  interface{}(
+- 	&fmt.Stringer(nil),
+  )
+>>> TestDiff/Comparer#30
+<<< TestDiff/Comparer#31
+  []cmp_test.tarHeader{
+  	{
+  		... // 4 identical fields
+  		Size:     1,
+  		ModTime:  s"2009-11-10 23:00:00 +0000 UTC",
+- 		Typeflag: 0x30,
++ 		Typeflag: 0x00,
+  		Linkname: "",
+  		Uname:    "user",
+  		... // 6 identical fields
+  	},
+  	{
+  		... // 4 identical fields
+  		Size:     2,
+  		ModTime:  s"2009-11-11 00:00:00 +0000 UTC",
+- 		Typeflag: 0x30,
++ 		Typeflag: 0x00,
+  		Linkname: "",
+  		Uname:    "user",
+  		... // 6 identical fields
+  	},
+  	{
+  		... // 4 identical fields
+  		Size:     4,
+  		ModTime:  s"2009-11-11 01:00:00 +0000 UTC",
+- 		Typeflag: 0x30,
++ 		Typeflag: 0x00,
+  		Linkname: "",
+  		Uname:    "user",
+  		... // 6 identical fields
+  	},
+  	{
+  		... // 4 identical fields
+  		Size:     8,
+  		ModTime:  s"2009-11-11 02:00:00 +0000 UTC",
+- 		Typeflag: 0x30,
++ 		Typeflag: 0x00,
+  		Linkname: "",
+  		Uname:    "user",
+  		... // 6 identical fields
+  	},
+  	{
+  		... // 4 identical fields
+  		Size:     16,
+  		ModTime:  s"2009-11-11 03:00:00 +0000 UTC",
+- 		Typeflag: 0x30,
++ 		Typeflag: 0x00,
+  		Linkname: "",
+  		Uname:    "user",
+  		... // 6 identical fields
+  	},
+  }
+>>> TestDiff/Comparer#31
+<<< TestDiff/Comparer#36
+  []int{
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+- 	Inverse(λ, float64(NaN)),
++ 	Inverse(λ, float64(NaN)),
+  }
+>>> TestDiff/Comparer#36
+<<< TestDiff/Comparer#37
+  map[*testprotos.Stringer]*testprotos.Stringer(
+- 	{s"hello": s"world"},
++ 	nil,
+  )
+>>> TestDiff/Comparer#37
+<<< TestDiff/Comparer#38
+  interface{}(
+- 	[]*testprotos.Stringer{s`multi\nline\nline\nline`},
+  )
+>>> TestDiff/Comparer#38
+<<< TestDiff/Comparer#42
+  []interface{}{
+  	map[string]interface{}{
+  		"avg":  float64(0.278),
+- 		"hr":   int(65),
++ 		"hr":   float64(65),
+  		"name": string("Mark McGwire"),
+  	},
+  	map[string]interface{}{
+  		"avg":  float64(0.288),
+- 		"hr":   int(63),
++ 		"hr":   float64(63),
+  		"name": string("Sammy Sosa"),
+  	},
+  }
+>>> TestDiff/Comparer#42
+<<< TestDiff/Comparer#43
+  map[*int]string{
+- 	⟪0xdeadf00f⟫: "hello",
++ 	⟪0xdeadf00f⟫: "world",
+  }
+>>> TestDiff/Comparer#43
+<<< TestDiff/Comparer#44
+  (*int)(
+- 	&0,
++ 	&0,
+  )
+>>> TestDiff/Comparer#44
+<<< TestDiff/Comparer#45
+  [2][]int{
+  	{..., 1, 2, 3, ..., 4, 5, 6, 7, ..., 8, ..., 9, ...},
+  	{
+  		... // 6 ignored and 1 identical elements
+- 		20,
++ 		2,
+  		... // 3 ignored elements
+  	},
+  }
+>>> TestDiff/Comparer#45
+<<< TestDiff/Comparer#46
+  [2]map[string]int{
+  	{"KEEP3": 3, "keep1": 1, "keep2": 2, ...},
+  	{
+  		... // 2 ignored entries
+  		"keep1": 1,
++ 		"keep2": 2,
+  	},
+  }
+>>> TestDiff/Comparer#46
+<<< TestDiff/Transformer
+  uint8(Inverse(λ, uint16(Inverse(λ, uint32(Inverse(λ, uint64(
+- 	0x00,
++ 	0x01,
+  )))))))
+>>> TestDiff/Transformer
+<<< TestDiff/Transformer#02
+  []int{
+  	Inverse(λ, int64(0)),
+- 	Inverse(λ, int64(-5)),
++ 	Inverse(λ, int64(3)),
+  	Inverse(λ, int64(0)),
+- 	Inverse(λ, int64(-1)),
++ 	Inverse(λ, int64(-5)),
+  }
+>>> TestDiff/Transformer#02
+<<< TestDiff/Transformer#03
+  int(Inverse(λ, interface{}(
+- 	string("zero"),
++ 	float64(1),
+  )))
+>>> TestDiff/Transformer#03
+<<< TestDiff/Transformer#04
+  string(Inverse(ParseJSON, map[string]interface{}{
+  	"address": map[string]interface{}{
+- 		"city":          string("Los Angeles"),
++ 		"city":          string("New York"),
+  		"postalCode":    string("10021-3100"),
+- 		"state":         string("CA"),
++ 		"state":         string("NY"),
+  		"streetAddress": string("21 2nd Street"),
+  	},
+  	"age":       float64(25),
+  	"children":  []interface{}{},
+  	"firstName": string("John"),
+  	"isAlive":   bool(true),
+  	"lastName":  string("Smith"),
+  	"phoneNumbers": []interface{}{
+  		map[string]interface{}{
+- 			"number": string("212 555-4321"),
++ 			"number": string("212 555-1234"),
+  			"type":   string("home"),
+  		},
+  		map[string]interface{}{"number": string("646 555-4567"), "type": string("office")},
+  		map[string]interface{}{"number": string("123 456-7890"), "type": string("mobile")},
+  	},
++ 	"spouse": nil,
+  }))
+>>> TestDiff/Transformer#04
+<<< TestDiff/Transformer#05
+  cmp_test.StringBytes{
+  	String: Inverse(SplitString, []string{
+  		"some",
+  		"multi",
+- 		"Line",
++ 		"line",
+  		"string",
+  	}),
+  	Bytes: []uint8(Inverse(SplitBytes, [][]uint8{
+  		{0x73, 0x6f, 0x6d, 0x65},
+  		{0x6d, 0x75, 0x6c, 0x74, 0x69},
+  		{0x6c, 0x69, 0x6e, 0x65},
+  		{
+- 			0x62,
++ 			0x42,
+  			0x79,
+  			0x74,
+  			... // 2 identical elements
+  		},
+  	})),
+  }
+>>> TestDiff/Transformer#05
+<<< TestDiff/Reporter
+  cmp_test.MyComposite{
+  	... // 3 identical fields
+  	BytesB: nil,
+  	BytesC: nil,
+  	IntsA: []int8{
++ 		10,
+  		11,
+- 		12,
++ 		21,
+  		13,
+  		14,
+  		... // 15 identical elements
+  	},
+  	IntsB: nil,
+  	IntsC: nil,
+  	... // 6 identical fields
+  }
+>>> TestDiff/Reporter
+<<< TestDiff/Reporter#01
+  cmp_test.MyComposite{
+  	... // 3 identical fields
+  	BytesB: nil,
+  	BytesC: nil,
+  	IntsA: []int8{
+- 		10, 11, 12, 13, 14, 15, 16,
++ 		12, 29, 13, 27, 22, 23,
+  		17, 18, 19, 20, 21,
+- 		22, 23, 24, 25, 26, 27, 28, 29,
++ 		10, 26, 16, 25, 28, 11, 15, 24, 14,
+  	},
+  	IntsB: nil,
+  	IntsC: nil,
+  	... // 6 identical fields
+  }
+>>> TestDiff/Reporter#01
+<<< TestDiff/Reporter#02
+  cmp_test.MyComposite{
+  	StringA: "",
+  	StringB: "",
+  	BytesA: []uint8{
+- 		0x01, 0x02, 0x03, // -|...|
++ 		0x03, 0x02, 0x01, // +|...|
+  	},
+  	BytesB: []cmp_test.MyByte{
+- 		0x04, 0x05, 0x06,
++ 		0x06, 0x05, 0x04,
+  	},
+  	BytesC: cmp_test.MyBytes{
+- 		0x07, 0x08, 0x09, // -|...|
++ 		0x09, 0x08, 0x07, // +|...|
+  	},
+  	IntsA: []int8{
+- 		-1, -2, -3,
++ 		-3, -2, -1,
+  	},
+  	IntsB: []cmp_test.MyInt{
+- 		-4, -5, -6,
++ 		-6, -5, -4,
+  	},
+  	IntsC: cmp_test.MyInts{
+- 		-7, -8, -9,
++ 		-9, -8, -7,
+  	},
+  	UintsA: []uint16{
+- 		0x03e8, 0x07d0, 0x0bb8,
++ 		0x0bb8, 0x07d0, 0x03e8,
+  	},
+  	UintsB: []cmp_test.MyUint{
+- 		4000, 5000, 6000,
++ 		6000, 5000, 4000,
+  	},
+  	UintsC: cmp_test.MyUints{
+- 		7000, 8000, 9000,
++ 		9000, 8000, 7000,
+  	},
+  	FloatsA: []float32{
+- 		1.5, 2.5, 3.5,
++ 		3.5, 2.5, 1.5,
+  	},
+  	FloatsB: []cmp_test.MyFloat{
+- 		4.5, 5.5, 6.5,
++ 		6.5, 5.5, 4.5,
+  	},
+  	FloatsC: cmp_test.MyFloats{
+- 		7.5, 8.5, 9.5,
++ 		9.5, 8.5, 7.5,
+  	},
+  }
+>>> TestDiff/Reporter#02
+<<< TestDiff/Reporter#03
+  cmp_test.MyComposite{
+  	StringA: "",
+  	StringB: "",
+  	BytesA: []uint8{
+  		0xf3, 0x0f, 0x8a, 0xa4, 0xd3, 0x12, 0x52, 0x09, 0x24, 0xbe,                                     //  |......R.$.|
+- 		0x58, 0x95, 0x41, 0xfd, 0x24, 0x66, 0x58, 0x8b, 0x79,                                           // -|X.A.$fX.y|
+  		0x54, 0xac, 0x0d, 0xd8, 0x71, 0x77, 0x70, 0x20, 0x6a, 0x5c, 0x73, 0x7f, 0x8c, 0x17, 0x55, 0xc0, //  |T...qwp j\s...U.|
+  		0x34, 0xce, 0x6e, 0xf7, 0xaa, 0x47, 0xee, 0x32, 0x9d, 0xc5, 0xca, 0x1e, 0x58, 0xaf, 0x8f, 0x27, //  |4.n..G.2....X..'|
+  		0xf3, 0x02, 0x4a, 0x90, 0xed, 0x69, 0x2e, 0x70, 0x32, 0xb4, 0xab, 0x30, 0x20, 0xb6, 0xbd, 0x5c, //  |..J..i.p2..0 ..\|
+  		0x62, 0x34, 0x17, 0xb0, 0x00, 0xbb, 0x4f, 0x7e, 0x27, 0x47, 0x06, 0xf4, 0x2e, 0x66, 0xfd, 0x63, //  |b4....O~'G...f.c|
+  		0xd7, 0x04, 0xdd, 0xb7, 0x30, 0xb7, 0xd1,                                                       //  |....0..|
+- 		0x55, 0x7e, 0x7b, 0xf6, 0xb3, 0x7e, 0x1d, 0x57, 0x69,                                           // -|U~{..~.Wi|
++ 		0x75, 0x2d, 0x5b, 0x5d, 0x5d, 0xf6, 0xb3, 0x68, 0x61, 0x68, 0x61, 0x7e, 0x1d, 0x57, 0x49,       // +|u-[]]..haha~.WI|
+  		0x20, 0x9e, 0xbc, 0xdf, 0xe1, 0x4d, 0xa9, 0xef, 0xa2, 0xd2, 0xed, 0xb4, 0x47, 0x78, 0xc9, 0xc9, //  | ....M......Gx..|
+  		0x27, 0xa4, 0xc6, 0xce, 0xec, 0x44, 0x70, 0x5d,                                                 //  |'....Dp]|
+  	},
+  	BytesB: nil,
+  	BytesC: nil,
+  	... // 9 identical fields
+  }
+>>> TestDiff/Reporter#03
+<<< TestDiff/Reporter#04
+  cmp_test.MyComposite{
+  	StringA: "",
+  	StringB: cmp_test.MyString{
+- 		0x72, 0x65, 0x61, 0x64, 0x6d, 0x65,                                                             // -|readme|
++ 		0x67, 0x6f, 0x70, 0x68, 0x65, 0x72,                                                             // +|gopher|
+  		0x2e, 0x74, 0x78, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |.txt............|
+  		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |................|
+  		... // 64 identical bytes
+  		0x30, 0x30, 0x36, 0x30, 0x30, 0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x30, //  |00600.0000000.00|
+  		0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, //  |00000.0000000004|
+- 		0x36,                                                                                           // -|6|
++ 		0x33,                                                                                           // +|3|
+  		0x00, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x00, 0x30, 0x31, 0x31, //  |.00000000000.011|
+- 		0x31, 0x37, 0x33,                                                                               // -|173|
++ 		0x32, 0x31, 0x37,                                                                               // +|217|
+  		0x00, 0x20, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |. 0.............|
+  		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  |................|
+  		... // 326 identical bytes
+  	},
+  	BytesA: nil,
+  	BytesB: nil,
+  	... // 10 identical fields
+  }
+>>> TestDiff/Reporter#04
+<<< TestDiff/Reporter#05
+  cmp_test.MyComposite{
+  	StringA: "",
+  	StringB: "",
+  	BytesA: bytes.Join({
+  		`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"`,
+  		`address":{"streetAddress":"`,
+- 		"314 54th Avenue",
++ 		"21 2nd Street",
+  		`","city":"New York","state":"NY","postalCode":"10021-3100"},"pho`,
+  		`neNumbers":[{"type":"home","number":"212 555-1234"},{"type":"off`,
+  		... // 101 identical bytes
+  	}, ""),
+  	BytesB: nil,
+  	BytesC: nil,
+  	... // 9 identical fields
+  }
+>>> TestDiff/Reporter#05
+<<< TestDiff/Reporter#06
+  cmp_test.MyComposite{
+  	StringA: strings.Join({
+- 		"Package cmp determines equality of values.",
++ 		"Package cmp determines equality of value.",
+  		"",
+  		"This package is intended to be a more powerful and safer alternative to",
+  		... // 6 identical lines
+  		"For example, an equality function may report floats as equal so long as they",
+  		"are within some tolerance of each other.",
+- 		"",
+- 		"• Types that have an Equal method may use that method to determine equality.",
+- 		"This allows package authors to determine the equality operation for the types",
+- 		"that they define.",
+  		"",
+  		"• If no custom equality functions are used and no Equal method is defined,",
+  		... // 3 identical lines
+  		"by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly compared",
+  		"using the AllowUnexported option.",
+- 		"",
+  	}, "\n"),
+  	StringB: "",
+  	BytesA:  nil,
+  	... // 11 identical fields
+  }
+>>> TestDiff/Reporter#06
+<<< TestDiff/EmbeddedStruct/ParentStructA#04
+  teststructs.ParentStructA{
+  	privateStruct: teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructA#04
+<<< TestDiff/EmbeddedStruct/ParentStructB#04
+  teststructs.ParentStructB{
+  	PublicStruct: teststructs.PublicStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructB#04
+<<< TestDiff/EmbeddedStruct/ParentStructC#04
+  teststructs.ParentStructC{
+  	privateStruct: teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+- 	Public:  3,
++ 	Public:  4,
+- 	private: 4,
++ 	private: 5,
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructC#04
+<<< TestDiff/EmbeddedStruct/ParentStructD#04
+  teststructs.ParentStructD{
+  	PublicStruct: teststructs.PublicStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+- 	Public:  3,
++ 	Public:  4,
+- 	private: 4,
++ 	private: 5,
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructD#04
+<<< TestDiff/EmbeddedStruct/ParentStructE#05
+  teststructs.ParentStructE{
+  	privateStruct: teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  	PublicStruct: teststructs.PublicStruct{
+- 		Public:  3,
++ 		Public:  4,
+- 		private: 4,
++ 		private: 5,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructE#05
+<<< TestDiff/EmbeddedStruct/ParentStructF#05
+  teststructs.ParentStructF{
+  	privateStruct: teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  	PublicStruct: teststructs.PublicStruct{
+- 		Public:  3,
++ 		Public:  4,
+- 		private: 4,
++ 		private: 5,
+  	},
+- 	Public:  5,
++ 	Public:  6,
+- 	private: 6,
++ 	private: 7,
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructF#05
+<<< TestDiff/EmbeddedStruct/ParentStructG#04
+  &teststructs.ParentStructG{
+  	privateStruct: &teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructG#04
+<<< TestDiff/EmbeddedStruct/ParentStructH#05
+  &teststructs.ParentStructH{
+  	PublicStruct: &teststructs.PublicStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructH#05
+<<< TestDiff/EmbeddedStruct/ParentStructI#06
+  &teststructs.ParentStructI{
+  	privateStruct: &teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  	PublicStruct: &teststructs.PublicStruct{
+- 		Public:  3,
++ 		Public:  4,
+- 		private: 4,
++ 		private: 5,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructI#06
+<<< TestDiff/EmbeddedStruct/ParentStructJ#05
+  &teststructs.ParentStructJ{
+  	privateStruct: &teststructs.privateStruct{
+- 		Public:  1,
++ 		Public:  2,
+- 		private: 2,
++ 		private: 3,
+  	},
+  	PublicStruct: &teststructs.PublicStruct{
+- 		Public:  3,
++ 		Public:  4,
+- 		private: 4,
++ 		private: 5,
+  	},
+  	Public: teststructs.PublicStruct{
+- 		Public:  7,
++ 		Public:  8,
+- 		private: 8,
++ 		private: 9,
+  	},
+  	private: teststructs.privateStruct{
+- 		Public:  5,
++ 		Public:  6,
+- 		private: 6,
++ 		private: 7,
+  	},
+  }
+>>> TestDiff/EmbeddedStruct/ParentStructJ#05
+<<< TestDiff/EqualMethod/StructB
+  teststructs.StructB{
+- 	X: "NotEqual",
++ 	X: "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructB
+<<< TestDiff/EqualMethod/StructD
+  teststructs.StructD{
+- 	X: "NotEqual",
++ 	X: "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructD
+<<< TestDiff/EqualMethod/StructE
+  teststructs.StructE{
+- 	X: "NotEqual",
++ 	X: "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructE
+<<< TestDiff/EqualMethod/StructF
+  teststructs.StructF{
+- 	X: "NotEqual",
++ 	X: "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructF
+<<< TestDiff/EqualMethod/StructA1#01
+  teststructs.StructA1{
+  	StructA: teststructs.StructA{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructA1#01
+<<< TestDiff/EqualMethod/StructA1#03
+  &teststructs.StructA1{
+  	StructA: teststructs.StructA{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructA1#03
+<<< TestDiff/EqualMethod/StructB1#01
+  teststructs.StructB1{
+  	StructB: teststructs.StructB(Inverse(Ref, &teststructs.StructB{X: "NotEqual"})),
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructB1#01
+<<< TestDiff/EqualMethod/StructB1#03
+  &teststructs.StructB1{
+  	StructB: teststructs.StructB(Inverse(Ref, &teststructs.StructB{X: "NotEqual"})),
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructB1#03
+<<< TestDiff/EqualMethod/StructD1
+  teststructs.StructD1{
+- 	StructD: teststructs.StructD{X: "NotEqual"},
++ 	StructD: teststructs.StructD{X: "not_equal"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructD1
+<<< TestDiff/EqualMethod/StructE1
+  teststructs.StructE1{
+- 	StructE: teststructs.StructE{X: "NotEqual"},
++ 	StructE: teststructs.StructE{X: "not_equal"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructE1
+<<< TestDiff/EqualMethod/StructF1
+  teststructs.StructF1{
+- 	StructF: teststructs.StructF{X: "NotEqual"},
++ 	StructF: teststructs.StructF{X: "not_equal"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructF1
+<<< TestDiff/EqualMethod/StructA2#01
+  teststructs.StructA2{
+  	StructA: &teststructs.StructA{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructA2#01
+<<< TestDiff/EqualMethod/StructA2#03
+  &teststructs.StructA2{
+  	StructA: &teststructs.StructA{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructA2#03
+<<< TestDiff/EqualMethod/StructB2#01
+  teststructs.StructB2{
+  	StructB: &teststructs.StructB{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructB2#01
+<<< TestDiff/EqualMethod/StructB2#03
+  &teststructs.StructB2{
+  	StructB: &teststructs.StructB{X: "NotEqual"},
+- 	X:       "NotEqual",
++ 	X:       "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructB2#03
+<<< TestDiff/EqualMethod/StructNo
+  teststructs.StructNo{
+- 	X: "NotEqual",
++ 	X: "not_equal",
+  }
+>>> TestDiff/EqualMethod/StructNo
+<<< TestDiff/Cycle#01
+  &&cmp_test.P(
+- 	&⟪0xdeadf00f⟫,
++ 	&&⟪0xdeadf00f⟫,
+  )
+>>> TestDiff/Cycle#01
+<<< TestDiff/Cycle#03
+  cmp_test.S{
+- 	{{{*(*cmp_test.S)(⟪0xdeadf00f⟫)}}},
++ 	{{{{*(*cmp_test.S)(⟪0xdeadf00f⟫)}}}},
+  }
+>>> TestDiff/Cycle#03
+<<< TestDiff/Cycle#05
+  cmp_test.M{
+- 	0: {0: ⟪0xdeadf00f⟫},
++ 	0: {0: {0: ⟪0xdeadf00f⟫}},
+  }
+>>> TestDiff/Cycle#05
+<<< TestDiff/Cycle#07
+  map[string]*cmp_test.CycleAlpha{
+  	"Bar": &{
+  		Name: "Bar",
+  		Bravos: map[string]*cmp_test.CycleBravo{
+  			"BarBuzzBravo": &{
+- 				ID:   102,
++ 				ID:   0,
+  				Name: "BarBuzzBravo",
+  				Mods: 2,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  					"Buzz": &{
+  						Name: "Buzz",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
+  							"BuzzBarBravo": &{
+- 								ID:     103,
++ 								ID:     0,
+  								Name:   "BuzzBarBravo",
+  								Mods:   0,
+  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"BuzzBarBravo": &{
+- 				ID:   103,
++ 				ID:   0,
+  				Name: "BuzzBarBravo",
+  				Mods: 0,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  					"Buzz": &{
+  						Name: "Buzz",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{
+- 								ID:     102,
++ 								ID:     0,
+  								Name:   "BarBuzzBravo",
+  								Mods:   2,
+  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
+  							},
+  							"BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": ⟪0xdeadf00f⟫}},
+  						},
+  					},
+  				},
+  			},
+  		},
+  	},
+  	"Buzz": &{
+  		Name: "Buzz",
+  		Bravos: map[string]*cmp_test.CycleBravo{
+  			"BarBuzzBravo": &{
+- 				ID:   102,
++ 				ID:   0,
+  				Name: "BarBuzzBravo",
+  				Mods: 2,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{
+  						Name: "Bar",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
+  							"BuzzBarBravo": &{
+- 								ID:     103,
++ 								ID:     0,
+  								Name:   "BuzzBarBravo",
+  								Mods:   0,
+  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
+  							},
+  						},
+  					},
+  					"Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  				},
+  			},
+  			"BuzzBarBravo": &{
+- 				ID:   103,
++ 				ID:   0,
+  				Name: "BuzzBarBravo",
+  				Mods: 0,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{
+  						Name: "Bar",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{
+- 								ID:     102,
++ 								ID:     0,
+  								Name:   "BarBuzzBravo",
+  								Mods:   2,
+  								Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}},
+  							},
+  							"BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": ⟪0xdeadf00f⟫}},
+  						},
+  					},
+  					"Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  				},
+  			},
+  		},
+  	},
+  	"Foo": &{
+  		Name: "Foo",
+  		Bravos: map[string]*cmp_test.CycleBravo{
+  			"FooBravo": &{
+- 				ID:     101,
++ 				ID:     0,
+  				Name:   "FooBravo",
+  				Mods:   100,
+  				Alphas: map[string]*cmp_test.CycleAlpha{"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": ⟪0xdeadf00f⟫}}}}},
+  			},
+  		},
+  	},
+  }
+>>> TestDiff/Cycle#07
+<<< TestDiff/Cycle#08
+  map[string]*cmp_test.CycleAlpha{
+  	"Bar": &{
+  		Name: "Bar",
+  		Bravos: map[string]*cmp_test.CycleBravo{
+  			"BarBuzzBravo": &{
+  				ID:   102,
+  				Name: "BarBuzzBravo",
+  				Mods: 2,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  					"Buzz": &{
+  						Name: "Buzz",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}},
+  							"BuzzBarBravo": &{
+  								ID:     103,
+  								Name:   "BuzzBarBravo",
+  								Mods:   0,
+- 								Alphas: nil,
++ 								Alphas: map[string]*cmp_test.CycleAlpha{
++ 									"Bar": &{
++ 										Name: "Bar",
++ 										Bravos: map[string]*cmp_test.CycleBravo{
++ 											"BarBuzzBravo": &{
++ 												ID:   102,
++ 												Name: "BarBuzzBravo",
++ 												Mods: 2,
++ 												Alphas: map[string]*cmp_test.CycleAlpha{
++ 													"Bar": ⟪0xdeadf00f⟫,
++ 													"Buzz": &{
++ 														Name: "Buzz",
++ 														Bravos: map[string]*cmp_test.CycleBravo{
++ 															"BarBuzzBravo": ⟪0xdeadf00f⟫,
++ 															"BuzzBarBravo": &{
++ 																ID:     103,
++ 																Name:   "BuzzBarBravo",
++ 																Alphas: map[string]*cmp_test.CycleAlpha(⟪0xdeadf00f⟫),
++ 															},
++ 														},
++ 													},
++ 												},
++ 											},
++ 											"BuzzBarBravo": ⟪0xdeadf00f⟫,
++ 										},
++ 									},
++ 									"Buzz": ⟪0xdeadf00f⟫,
++ 								},
+  							},
+  						},
+  					},
+  				},
+  			},
+  			"BuzzBarBravo": &{
+  				ID:   103,
+  				Name: "BuzzBarBravo",
+  				Mods: 0,
+  				Alphas: map[string]*cmp_test.CycleAlpha{
+  					"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}},
+  					"Buzz": &{
+  						Name: "Buzz",
+  						Bravos: map[string]*cmp_test.CycleBravo{
+  							"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}},
+- 							"BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo"},
++ 							"BuzzBarBravo": &{
++ 								ID:   103,
++ 								Name: "BuzzBarBravo",
++ 								Alphas: map[string]*cmp_test.CycleAlpha{
++ 									"Bar": &{
++ 										Name: "Bar",
++ 										Bravos: map[string]*cmp_test.CycleBravo{
++ 											"BarBuzzBravo": &{
++ 												ID:   102,
++ 												Name: "BarBuzzBravo",
++ 												Mods: 2,
++ 												Alphas: map[string]*cmp_test.CycleAlpha{
++ 													"Bar": ⟪0xdeadf00f⟫,
++ 													"Buzz": &{
++ 														Name:   "Buzz",
++ 														Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫},
++ 													},
++ 												},
++ 											},
++ 											"BuzzBarBravo": ⟪0xdeadf00f⟫,
++ 										},
++ 									},
++ 									"Buzz": ⟪0xdeadf00f⟫,
++ 								},
++ 							},
+  						},
+  					},
+  				},
+  			},
+  		},
+  	},
+  	"Buzz": &{
+  		Name: "Buzz",
+  		Bravos: map[string]*cmp_test.CycleBravo{
+  			"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}}}}, "Buzz": &{Name: "Buzz", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": &{ID: 102, Name: "BarBuzzBravo", Mods: 2, Alphas: map[string]*cmp_test.CycleAlpha{"Bar": &{Name: "Bar", Bravos: map[string]*cmp_test.CycleBravo{"BarBuzzBravo": ⟪0xdeadf00f⟫, "BuzzBarBravo": &{ID: 103, Name: "BuzzBarBravo", Alphas: map[string]*cmp_test.CycleAlpha{"Bar": ⟪0xdeadf00f⟫, "Buzz": ⟪0xdeadf00f⟫}}}}, "Buzz": ⟪0xdeadf00f⟫}}, "BuzzBarBravo": ⟪0xdeadf00f⟫}}}},
+  			"BuzzBarBravo": &{
+  				ID:     103,
+  				Name:   "BuzzBarBravo",
+  				Mods:   0,
+- 				Alphas: nil,
++ 				Alphas: map[string]*cmp_test.CycleAlpha{
++ 					"Bar": &{
++ 						Name: "Bar",
++ 						Bravos: map[string]*cmp_test.CycleBravo{
++ 							"BarBuzzBravo": &{
++ 								ID:   102,
++ 								Name: "BarBuzzBravo",
++ 								Mods: 2,
++ 								Alphas: map[string]*cmp_test.CycleAlpha{
++ 									"Bar": ⟪0xdeadf00f⟫,
++ 									"Buzz": &{
++ 										Name: "Buzz",
++ 										Bravos: map[string]*cmp_test.CycleBravo{
++ 											"BarBuzzBravo": ⟪0xdeadf00f⟫,
++ 											"BuzzBarBravo": &{
++ 												ID:     103,
++ 												Name:   "BuzzBarBravo",
++ 												Alphas: map[string]*cmp_test.CycleAlpha(⟪0xdeadf00f⟫),
++ 											},
++ 										},
++ 									},
++ 								},
++ 							},
++ 							"BuzzBarBravo": ⟪0xdeadf00f⟫,
++ 						},
++ 					},
++ 					"Buzz": ⟪0xdeadf00f⟫,
++ 				},
+  			},
+  		},
+  	},
+  	"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{ID: 101, Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": &{Name: "Foo", Bravos: map[string]*cmp_test.CycleBravo{"FooBravo": &{ID: 101, Name: "FooBravo", Mods: 100, Alphas: map[string]*cmp_test.CycleAlpha{"Foo": ⟪0xdeadf00f⟫}}}}}}}},
+  }
+>>> TestDiff/Cycle#08
+<<< TestDiff/Project1#02
+  teststructs.Eagle{
+  	... // 4 identical fields
+  	Dreamers: nil,
+  	Prong:    0,
+  	Slaps: []teststructs.Slap{
+  		... // 2 identical elements
+  		{},
+  		{},
+  		{
+  			Name:     "",
+  			Desc:     "",
+  			DescLong: "",
+- 			Args:     s"metadata",
++ 			Args:     s"metadata2",
+  			Tense:    0,
+  			Interval: 0,
+  			... // 3 identical fields
+  		},
+  	},
+  	StateGoverner: "",
+  	PrankRating:   "",
+  	... // 2 identical fields
+  }
+>>> TestDiff/Project1#02
+<<< TestDiff/Project1#04
+  teststructs.Eagle{
+  	... // 2 identical fields
+  	Desc:     "some description",
+  	DescLong: "",
+  	Dreamers: []teststructs.Dreamer{
+  		{},
+  		{
+  			... // 4 identical fields
+  			ContSlaps:         nil,
+  			ContSlapsInterval: 0,
+  			Animal: []interface{}{
+  				teststructs.Goat{
+  					Target:     "corporation",
+  					Slaps:      nil,
+  					FunnyPrank: "",
+  					Immutable: &teststructs.GoatImmutable{
+- 						ID:      "southbay2",
++ 						ID:      "southbay",
+- 						State:   &6,
++ 						State:   &5,
+  						Started: s"2009-11-10 23:00:00 +0000 UTC",
+  						Stopped: s"0001-01-01 00:00:00 +0000 UTC",
+  						... // 1 ignored and 1 identical fields
+  					},
+  				},
+  				teststructs.Donkey{},
+  			},
+  			Ornamental: false,
+  			Amoeba:     53,
+  			... // 5 identical fields
+  		},
+  	},
+  	Prong: 0,
+  	Slaps: []teststructs.Slap{
+  		{
+  			... // 6 identical fields
+  			Homeland:   0x00,
+  			FunnyPrank: "",
+  			Immutable: &teststructs.SlapImmutable{
+  				ID:          "immutableSlap",
+  				Out:         nil,
+- 				MildSlap:    false,
++ 				MildSlap:    true,
+  				PrettyPrint: "",
+  				State:       nil,
+  				Started:     s"2009-11-10 23:00:00 +0000 UTC",
+  				Stopped:     s"0001-01-01 00:00:00 +0000 UTC",
+  				LastUpdate:  s"0001-01-01 00:00:00 +0000 UTC",
+  				LoveRadius: &teststructs.LoveRadius{
+  					Summer: &teststructs.SummerLove{
+  						Summary: &teststructs.SummerLoveSummary{
+  							Devices: []string{
+  								"foo",
+- 								"bar",
+- 								"baz",
+  							},
+  							ChangeType: []testprotos.SummerType{1, 2, 3},
+  							... // 1 ignored field
+  						},
+  						... // 1 ignored field
+  					},
+  					... // 1 ignored field
+  				},
+  				... // 1 ignored field
+  			},
+  		},
+  	},
+  	StateGoverner: "",
+  	PrankRating:   "",
+  	... // 2 identical fields
+  }
+>>> TestDiff/Project1#04
+<<< TestDiff/Project2#02
+  teststructs.GermBatch{
+  	DirtyGerms: map[int32][]*testprotos.Germ{
+  		17: {s"germ1"},
+  		18: {
+- 			s"germ2",
+  			s"germ3",
+  			s"germ4",
++ 			s"germ2",
+  		},
+  	},
+  	CleanGerms: nil,
+  	GermMap:    map[int32]*testprotos.Germ{13: s"germ13", 21: s"germ21"},
+  	... // 7 identical fields
+  }
+>>> TestDiff/Project2#02
+<<< TestDiff/Project2#04
+  teststructs.GermBatch{
+  	DirtyGerms: map[int32][]*testprotos.Germ{
++ 		17: {s"germ1"},
+  		18: Inverse(Sort, []*testprotos.Germ{
+  			s"germ2",
+  			s"germ3",
+- 			s"germ4",
+  		}),
+  	},
+  	CleanGerms: nil,
+  	GermMap:    map[int32]*testprotos.Germ{13: s"germ13", 21: s"germ21"},
+  	DishMap: map[int32]*teststructs.Dish{
+  		0: &{err: &errors.errorString{s: "EOF"}},
+- 		1: nil,
++ 		1: &{err: &errors.errorString{s: "unexpected EOF"}},
+  		2: &{pb: &testprotos.Dish{Stringer: testprotos.Stringer{X: "dish"}}},
+  	},
+  	HasPreviousResult: true,
+  	DirtyID:           10,
+  	CleanID:           0,
+- 	GermStrain:        421,
++ 	GermStrain:        22,
+  	TotalDirtyGerms:   0,
+  	InfectedAt:        s"2009-11-10 23:00:00 +0000 UTC",
+  }
+>>> TestDiff/Project2#04
+<<< TestDiff/Project3#03
+  teststructs.Dirt{
+- 	table:   &teststructs.MockTable{state: []string{"a", "c"}},
++ 	table:   &teststructs.MockTable{state: []string{"a", "b", "c"}},
+  	ts:      12345,
+- 	Discord: 554,
++ 	Discord: 500,
+- 	Proto:   testprotos.Dirt(Inverse(λ, s"blah")),
++ 	Proto:   testprotos.Dirt(Inverse(λ, s"proto")),
+  	wizard: map[string]*testprotos.Wizard{
+- 		"albus": s"dumbledore",
+- 		"harry": s"potter",
++ 		"harry": s"otter",
+  	},
+  	sadistic: nil,
+  	lastTime: 54321,
+  	... // 1 ignored field
+  }
+>>> TestDiff/Project3#03
+<<< TestDiff/Project4#03
+  teststructs.Cartel{
+  	Headquarter: teststructs.Headquarter{
+  		id:       0x05,
+  		location: "moon",
+  		subDivisions: []string{
+- 			"alpha",
+  			"bravo",
+  			"charlie",
+  		},
+  		incorporatedDate: s"0001-01-01 00:00:00 +0000 UTC",
+  		metaData:         s"metadata",
+  		privateMessage:   nil,
+  		publicMessage: []uint8{
+  			0x01,
+  			0x02,
+- 			0x03,
++ 			0x04,
+- 			0x04,
++ 			0x03,
+  			0x05,
+  		},
+  		horseBack: "abcdef",
+  		rattle:    "",
+  		... // 5 identical fields
+  	},
+  	source:        "mars",
+  	creationDate:  s"0001-01-01 00:00:00 +0000 UTC",
+  	boss:          "al capone",
+  	lastCrimeDate: s"0001-01-01 00:00:00 +0000 UTC",
+  	poisons: []*teststructs.Poison{
+  		&{
+- 			poisonType:   1,
++ 			poisonType:   5,
+  			expiration:   s"2009-11-10 23:00:00 +0000 UTC",
+  			manufacturer: "acme",
+  			potency:      0,
+  		},
+- 		&{poisonType: 2, manufacturer: "acme2"},
+  	},
+  }
+>>> TestDiff/Project4#03


### PR DESCRIPTION
Refactor the unit tests to read the diffs from a file
rather than being stored as a Go string literal.
The advantage of using a golden file is to ease
updating the diffs whenever the reporter output is changed.