### PR TITLE
Fix exporter to handle nil interface values

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -627,7 +627,7 @@ func comparerTests() []test {
 	}, {
 		label: label,
 		x:     struct{ s fmt.Stringer }{new(bytes.Buffer)},
-		y:     struct{ s fmt.Stringer }{new(bytes.Buffer)},
+		y:     struct{ s fmt.Stringer }{nil},
 		opts: []cmp.Option{
 			cmp.AllowUnexported(struct{ s fmt.Stringer }{}),
 			cmp.FilterPath(func(p cmp.Path) bool {

--- a/cmp/export_unsafe.go
+++ b/cmp/export_unsafe.go
@@ -26,7 +26,10 @@ func retrieveUnexportedField(v reflect.Value, f reflect.StructField, addr bool) 
 		// If the original parent value was not addressable, shallow copy the
 		// value to make it non-addressable to avoid leaking an implementation
 		// detail of how forcibly exporting a field works.
-		ve = reflect.ValueOf(ve.Interface()).Convert(f.Type)
+		if ve.Kind() == reflect.Interface && ve.IsNil() {
+			return reflect.Zero(f.Type)
+		}
+		return reflect.ValueOf(ve.Interface()).Convert(f.Type)
 	}
 	return ve
 }


### PR DESCRIPTION
A shallow copy with reflect.ValueOf(v.Interface()) does not work
if v is a nil interface value. Special case the edge case by
checking for a nil value and create a new one use reflect.Zero.