### PR TITLE
Mention minimally supported Go version in TODO

### DIFF
--- a/cmp/cmpopts/equate.go
+++ b/cmp/cmpopts/equate.go
@@ -151,6 +151,6 @@ func areConcreteErrors(x, y interface{}) bool {
 func compareErrors(x, y interface{}) bool {
 	xe := x.(error)
 	ye := y.(error)
-	// TODO: Use errors.Is when go1.13 is the minimally supported version of Go.
+	// TODO(≥go1.13): Use standard definition of errors.Is.
 	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
 }

--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -376,7 +376,7 @@ func detectRaces(c chan<- reflect.Value, f reflect.Value, vs ...reflect.Value) {
 // assuming that T is assignable to R.
 // Otherwise, it returns the input value as is.
 func sanitizeValue(v reflect.Value, t reflect.Type) reflect.Value {
-	// TODO(dsnet): Workaround for reflect bug (https://golang.org/issue/22143).
+	// TODO(≥go1.10): Workaround for reflect bug (https://golang.org/issue/22143).
 	if !flags.AtLeastGo110 {
 		if v.Kind() == reflect.Interface && v.IsNil() && v.Type() != t {
 			return reflect.New(t).Elem()

--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -1068,7 +1068,7 @@ func embeddedTests() []test {
 		return s
 	}
 
-	// TODO(dsnet): Workaround for reflect bug (https://golang.org/issue/21122).
+	// TODO(≥go1.10): Workaround for reflect bug (https://golang.org/issue/21122).
 	wantPanicNotGo110 := func(s string) string {
 		if !flags.AtLeastGo110 {
 			return ""


### PR DESCRIPTION
Specify the exact minimumally supported version of Go required
in order to address certain TODOs. This makes it easier to filter
out inactionable TODOs.