### PR TITLE
Introduce deliberate instability to difference output

### DIFF
--- a/cmp/internal/diff/diff_test.go
+++ b/cmp/internal/diff/diff_test.go
@@ -10,7 +10,13 @@ import (
 	"strings"
 	"testing"
 	"unicode"
+
+	"github.com/google/go-cmp/cmp/internal/flags"
 )
+
+func init() {
+	flags.Deterministic = true
+}
 
 func TestDifference(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The reporter output is documented as unstable.
The API for custom reporters also specifies that the diffing of
slices is unstable.

Introduce deliberate instability to the diffing algorithm so that
we have the flexibility to improve it in the future.
The current algorithm optimizes for speed, rather than optimality,
so there is much room for improvement.