### PR TITLE
Disambiguate reporter output

### DIFF
--- a/cmp/internal/teststructs/foo1/foo.go
+++ b/cmp/internal/teststructs/foo1/foo.go
@@ -1,0 +1,10 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package foo is deliberately named differently than the parent directory.
+// It contain declarations that have ambiguity in their short names,
+// relative to a different package also called foo.
+package foo
+
+type Bar struct{ S string }

--- a/cmp/internal/teststructs/foo2/foo.go
+++ b/cmp/internal/teststructs/foo2/foo.go
@@ -1,0 +1,10 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package foo is deliberately named differently than the parent directory.
+// It contain declarations that have ambiguity in their short names,
+// relative to a different package also called foo.
+package foo
+
+type Bar struct{ S string }

--- a/cmp/internal/value/name.go
+++ b/cmp/internal/value/name.go
@@ -1,0 +1,157 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package value
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// TypeString is nearly identical to reflect.Type.String,
+// but has an additional option to specify that full type names be used.
+func TypeString(t reflect.Type, qualified bool) string {
+	return string(appendTypeName(nil, t, qualified, false))
+}
+
+func appendTypeName(b []byte, t reflect.Type, qualified, elideFunc bool) []byte {
+	// BUG: Go reflection provides no way to disambiguate two named types
+	// of the same name and within the same package,
+	// but declared within the namespace of different functions.
+
+	// Named type.
+	if t.Name() != "" {
+		if qualified && t.PkgPath() != "" {
+			b = append(b, '"')
+			b = append(b, t.PkgPath()...)
+			b = append(b, '"')
+			b = append(b, '.')
+			b = append(b, t.Name()...)
+		} else {
+			b = append(b, t.String()...)
+		}
+		return b
+	}
+
+	// Unnamed type.
+	switch k := t.Kind(); k {
+	case reflect.Bool, reflect.String, reflect.UnsafePointer,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		b = append(b, k.String()...)
+	case reflect.Chan:
+		if t.ChanDir() == reflect.RecvDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, "chan"...)
+		if t.ChanDir() == reflect.SendDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, ' ')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Func:
+		if !elideFunc {
+			b = append(b, "func"...)
+		}
+		b = append(b, '(')
+		for i := 0; i < t.NumIn(); i++ {
+			if i > 0 {
+				b = append(b, ", "...)
+			}
+			if i == t.NumIn()-1 && t.IsVariadic() {
+				b = append(b, "..."...)
+				b = appendTypeName(b, t.In(i).Elem(), qualified, false)
+			} else {
+				b = appendTypeName(b, t.In(i), qualified, false)
+			}
+		}
+		b = append(b, ')')
+		switch t.NumOut() {
+		case 0:
+			// Do nothing
+		case 1:
+			b = append(b, ' ')
+			b = appendTypeName(b, t.Out(0), qualified, false)
+		default:
+			b = append(b, " ("...)
+			for i := 0; i < t.NumOut(); i++ {
+				if i > 0 {
+					b = append(b, ", "...)
+				}
+				b = appendTypeName(b, t.Out(i), qualified, false)
+			}
+			b = append(b, ')')
+		}
+	case reflect.Struct:
+		b = append(b, "struct{ "...)
+		for i := 0; i < t.NumField(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			sf := t.Field(i)
+			if !sf.Anonymous {
+				if qualified && sf.PkgPath != "" {
+					b = append(b, '"')
+					b = append(b, sf.PkgPath...)
+					b = append(b, '"')
+					b = append(b, '.')
+				}
+				b = append(b, sf.Name...)
+				b = append(b, ' ')
+			}
+			b = appendTypeName(b, sf.Type, qualified, false)
+			if sf.Tag != "" {
+				b = append(b, ' ')
+				b = strconv.AppendQuote(b, string(sf.Tag))
+			}
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	case reflect.Slice, reflect.Array:
+		b = append(b, '[')
+		if k == reflect.Array {
+			b = strconv.AppendUint(b, uint64(t.Len()), 10)
+		}
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Map:
+		b = append(b, "map["...)
+		b = appendTypeName(b, t.Key(), qualified, false)
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Ptr:
+		b = append(b, '*')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Interface:
+		b = append(b, "interface{ "...)
+		for i := 0; i < t.NumMethod(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			m := t.Method(i)
+			if qualified && m.PkgPath != "" {
+				b = append(b, '"')
+				b = append(b, m.PkgPath...)
+				b = append(b, '"')
+				b = append(b, '.')
+			}
+			b = append(b, m.Name...)
+			b = appendTypeName(b, m.Type, qualified, true)
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	default:
+		panic("invalid kind: " + k.String())
+	}
+	return b
+}

--- a/cmp/internal/value/name_test.go
+++ b/cmp/internal/value/name_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package value
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type Named struct{}
+
+var pkgPath = reflect.TypeOf(Named{}).PkgPath()
+
+func TestTypeString(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want string
+	}{{
+		in:   bool(false),
+		want: "bool",
+	}, {
+		in:   int(0),
+		want: "int",
+	}, {
+		in:   float64(0),
+		want: "float64",
+	}, {
+		in:   string(""),
+		want: "string",
+	}, {
+		in:   Named{},
+		want: "$PackagePath.Named",
+	}, {
+		in:   (chan Named)(nil),
+		want: "chan $PackagePath.Named",
+	}, {
+		in:   (<-chan Named)(nil),
+		want: "<-chan $PackagePath.Named",
+	}, {
+		in:   (chan<- Named)(nil),
+		want: "chan<- $PackagePath.Named",
+	}, {
+		in:   (func())(nil),
+		want: "func()",
+	}, {
+		in:   (func(Named))(nil),
+		want: "func($PackagePath.Named)",
+	}, {
+		in:   (func() Named)(nil),
+		want: "func() $PackagePath.Named",
+	}, {
+		in:   (func(int, Named) (int, error))(nil),
+		want: "func(int, $PackagePath.Named) (int, error)",
+	}, {
+		in:   (func(...Named))(nil),
+		want: "func(...$PackagePath.Named)",
+	}, {
+		in:   struct{}{},
+		want: "struct{}",
+	}, {
+		in:   struct{ Named }{},
+		want: "struct{ $PackagePath.Named }",
+	}, {
+		in: struct {
+			Named `tag`
+		}{},
+		want: "struct{ $PackagePath.Named \"tag\" }",
+	}, {
+		in:   struct{ Named Named }{},
+		want: "struct{ Named $PackagePath.Named }",
+	}, {
+		in: struct {
+			Named Named `tag`
+		}{},
+		want: "struct{ Named $PackagePath.Named \"tag\" }",
+	}, {
+		in: struct {
+			Int   int
+			Named Named
+		}{},
+		want: "struct{ Int int; Named $PackagePath.Named }",
+	}, {
+		in: struct {
+			_ int
+			x Named
+		}{},
+		want: "struct{ $FieldPrefix._ int; $FieldPrefix.x $PackagePath.Named }",
+	}, {
+		in:   []Named(nil),
+		want: "[]$PackagePath.Named",
+	}, {
+		in:   []*Named(nil),
+		want: "[]*$PackagePath.Named",
+	}, {
+		in:   [10]Named{},
+		want: "[10]$PackagePath.Named",
+	}, {
+		in:   [10]*Named{},
+		want: "[10]*$PackagePath.Named",
+	}, {
+		in:   map[string]string(nil),
+		want: "map[string]string",
+	}, {
+		in:   map[Named]Named(nil),
+		want: "map[$PackagePath.Named]$PackagePath.Named",
+	}, {
+		in:   (*Named)(nil),
+		want: "*$PackagePath.Named",
+	}, {
+		in:   (*interface{})(nil),
+		want: "*interface{}",
+	}, {
+		in:   (*interface{ Read([]byte) (int, error) })(nil),
+		want: "*interface{ Read([]uint8) (int, error) }",
+	}, {
+		in: (*interface {
+			F1()
+			F2(Named)
+			F3() Named
+			F4(int, Named) (int, error)
+			F5(...Named)
+		})(nil),
+		want: "*interface{ F1(); F2($PackagePath.Named); F3() $PackagePath.Named; F4(int, $PackagePath.Named) (int, error); F5(...$PackagePath.Named) }",
+	}}
+
+	for _, tt := range tests {
+		typ := reflect.TypeOf(tt.in)
+		wantShort := tt.want
+		wantShort = strings.Replace(wantShort, "$PackagePath", "value", -1)
+		wantShort = strings.Replace(wantShort, "$FieldPrefix.", "", -1)
+		if gotShort := TypeString(typ, false); gotShort != wantShort {
+			t.Errorf("TypeString(%v, false) mismatch:\ngot:  %v\nwant: %v", typ, gotShort, wantShort)
+		}
+		wantQualified := tt.want
+		wantQualified = strings.Replace(wantQualified, "$PackagePath", `"`+pkgPath+`"`, -1)
+		wantQualified = strings.Replace(wantQualified, "$FieldPrefix", `"`+pkgPath+`"`, -1)
+		if gotQualified := TypeString(typ, true); gotQualified != wantQualified {
+			t.Errorf("TypeString(%v, true) mismatch:\ngot:  %v\nwant: %v", typ, gotQualified, wantQualified)
+		}
+	}
+}

--- a/cmp/report_slices.go
+++ b/cmp/report_slices.go
@@ -26,8 +26,8 @@ func (opts formatOptions) CanFormatDiffSlice(v *valueNode) bool {
 		return false // No differences detected
 	case !v.ValueX.IsValid() || !v.ValueY.IsValid():
 		return false // Both values must be valid
-	case v.Type.Kind() == reflect.Slice && (v.ValueX.IsNil() || v.ValueY.IsNil()):
-		return false // Both of values have to be non-nil
+	case v.Type.Kind() == reflect.Slice && (v.ValueX.Len() == 0 || v.ValueY.Len() == 0):
+		return false // Both slice values have to be non-empty
 	case v.NumIgnored > 0:
 		return false // Some ignore option was used
 	case v.NumTransformed > 0:

--- a/cmp/report_text.go
+++ b/cmp/report_text.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp/internal/flags"
 )
@@ -239,14 +240,14 @@ func (s textList) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 			_, isLine := r.Value.(textLine)
 			return r.Key == "" || !isLine
 		},
-		func(r textRecord) int { return len(r.Key) },
+		func(r textRecord) int { return utf8.RuneCountInString(r.Key) },
 	)
 	alignValueLens := s.alignLens(
 		func(r textRecord) bool {
 			_, isLine := r.Value.(textLine)
 			return !isLine || r.Value.Equal(textEllipsis) || r.Comment == nil
 		},
-		func(r textRecord) int { return len(r.Value.(textLine)) },
+		func(r textRecord) int { return utf8.RuneCount(r.Value.(textLine)) },
 	)
 
 	// Format lists of simple lists in a batched form.

--- a/cmp/testdata/diffs
+++ b/cmp/testdata/diffs
@@ -160,12 +160,6 @@
   }
 >>> TestDiff/Comparer#43
 <<< TestDiff/Comparer#44
-  (*int)(
-- 	&0,
-+ 	&0,
-  )
->>> TestDiff/Comparer#44
-<<< TestDiff/Comparer#45
   [2][]int{
   	{..., 1, 2, 3, ...},
   	{
@@ -175,8 +169,8 @@
   		... // 3 ignored elements
   	},
   }
->>> TestDiff/Comparer#45
-<<< TestDiff/Comparer#46
+>>> TestDiff/Comparer#44
+<<< TestDiff/Comparer#45
   [2]map[string]int{
   	{"KEEP3": 3, "keep1": 1, "keep2": 2, ...},
   	{
@@ -185,7 +179,7 @@
 + 		"keep2": 2,
   	},
   }
->>> TestDiff/Comparer#46
+>>> TestDiff/Comparer#45
 <<< TestDiff/Transformer
   uint8(Inverse(λ, uint16(Inverse(λ, uint32(Inverse(λ, uint64(
 - 	0,
@@ -258,6 +252,81 @@
   	})),
   }
 >>> TestDiff/Transformer#05
+<<< TestDiff/Reporter/AmbiguousType
+  interface{}(
+- 	"github.com/google/go-cmp/cmp/internal/teststructs/foo1".Bar{},
++ 	"github.com/google/go-cmp/cmp/internal/teststructs/foo2".Bar{},
+  )
+>>> TestDiff/Reporter/AmbiguousType
+<<< TestDiff/Reporter/AmbiguousPointer
+  (*int)(
+- 	&⟪0xdeadf00f⟫0,
++ 	&⟪0xdeadf00f⟫0,
+  )
+>>> TestDiff/Reporter/AmbiguousPointer
+<<< TestDiff/Reporter/AmbiguousPointerStruct
+  struct{ I *int }{
+- 	I: &⟪0xdeadf00f⟫0,
++ 	I: &⟪0xdeadf00f⟫0,
+  }
+>>> TestDiff/Reporter/AmbiguousPointerStruct
+<<< TestDiff/Reporter/AmbiguousPointerSlice
+  []*int{
+- 	&⟪0xdeadf00f⟫0,
++ 	&⟪0xdeadf00f⟫0,
+  }
+>>> TestDiff/Reporter/AmbiguousPointerSlice
+<<< TestDiff/Reporter/AmbiguousPointerMap
+  map[string]*int{
+- 	"zero": &⟪0xdeadf00f⟫0,
++ 	"zero": &⟪0xdeadf00f⟫0,
+  }
+>>> TestDiff/Reporter/AmbiguousPointerMap
+<<< TestDiff/Reporter/AmbiguousStringer
+  interface{}(
+- 	cmp_test.Stringer("hello"),
++ 	&cmp_test.Stringer("hello"),
+  )
+>>> TestDiff/Reporter/AmbiguousStringer
+<<< TestDiff/Reporter/AmbiguousStringerStruct
+  struct{ S fmt.Stringer }{
+- 	S: cmp_test.Stringer("hello"),
++ 	S: &cmp_test.Stringer("hello"),
+  }
+>>> TestDiff/Reporter/AmbiguousStringerStruct
+<<< TestDiff/Reporter/AmbiguousStringerSlice
+  []fmt.Stringer{
+- 	cmp_test.Stringer("hello"),
++ 	&cmp_test.Stringer("hello"),
+  }
+>>> TestDiff/Reporter/AmbiguousStringerSlice
+<<< TestDiff/Reporter/AmbiguousStringerMap
+  map[string]fmt.Stringer{
+- 	"zero": cmp_test.Stringer("hello"),
++ 	"zero": &cmp_test.Stringer("hello"),
+  }
+>>> TestDiff/Reporter/AmbiguousStringerMap
+<<< TestDiff/Reporter/AmbiguousSliceHeader
+  []int(
+- 	⟪ptr:0xdeadf00f, len:0, cap:5⟫{},
++ 	⟪ptr:0xdeadf00f, len:0, cap:1000⟫{},
+  )
+>>> TestDiff/Reporter/AmbiguousSliceHeader
+<<< TestDiff/Reporter/AmbiguousStringerMapKey
+  map[interface{}]string{
+- 	nil:                                                                     "nil",
++ 	&⟪0xdeadf00f⟫"github.com/google/go-cmp/cmp_test".Stringer("hello"):      "goodbye",
+- 	"github.com/google/go-cmp/cmp_test".Stringer("hello"):                   "goodbye",
+- 	"github.com/google/go-cmp/cmp/internal/teststructs/foo1".Bar{S: "fizz"}: "buzz",
++ 	"github.com/google/go-cmp/cmp/internal/teststructs/foo2".Bar{S: "fizz"}: "buzz",
+  }
+>>> TestDiff/Reporter/AmbiguousStringerMapKey
+<<< TestDiff/Reporter/NonAmbiguousStringerMapKey
+  map[interface{}]string{
++ 	s"fizz":  "buzz",
+- 	s"hello": "goodbye",
+  }
+>>> TestDiff/Reporter/NonAmbiguousStringerMapKey
 <<< TestDiff//InvalidUTF8
   interface{}(
 - 	cmp_test.MyString("\xed\xa0\x80"),


### PR DESCRIPTION
The reporter tries to aggresively elide data that is not interesting
to the user. However, doing so many result in an output that does not
visually indicate the difference between semantically different objects.
This CL modifies the reporter try increasingly verbose settings until
two different objects are formatted differently.