### PR TITLE
Swallow panic when calling String or Error

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -874,6 +875,18 @@ func reporterTests() []test {
 	)
 
 	return []test{{
+		label:     label + "/PanicStringer",
+		x:         struct{ X fmt.Stringer }{struct{ fmt.Stringer }{nil}},
+		y:         struct{ X fmt.Stringer }{bytes.NewBuffer(nil)},
+		wantEqual: false,
+		reason:    "panic from fmt.Stringer should not crash the reporter",
+	}, {
+		label:     label + "/PanicError",
+		x:         struct{ X error }{struct{ error }{nil}},
+		y:         struct{ X error }{errors.New("")},
+		wantEqual: false,
+		reason:    "panic from error should not crash the reporter",
+	}, {
 		label:     label + "/AmbiguousType",
 		x:         foo1.Bar{},
 		y:         foo2.Bar{},

--- a/cmp/testdata/diffs
+++ b/cmp/testdata/diffs
@@ -252,6 +252,18 @@
   	})),
   }
 >>> TestDiff/Transformer/AcyclicString
+<<< TestDiff/Reporter/PanicStringer
+  struct{ X fmt.Stringer }{
+- 	X: struct{ fmt.Stringer }{},
++ 	X: s"",
+  }
+>>> TestDiff/Reporter/PanicStringer
+<<< TestDiff/Reporter/PanicError
+  struct{ X error }{
+- 	X: struct{ error }{},
++ 	X: e"",
+  }
+>>> TestDiff/Reporter/PanicError
 <<< TestDiff/Reporter/AmbiguousType
   interface{}(
 - 	"github.com/google/go-cmp/cmp/internal/teststructs/foo1".Bar{},


### PR DESCRIPTION
If a panic occurs while calling String or Error,
the reporter recovers from it and ignores it,
proceeding with its usual functionality for formatting a value.