### PR TITLE
Drop xerrors since functionality is merged to errors in std lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,6 @@ sudo: false
 language: go
 matrix:
   include:
-    - go: 1.8.x
-      script:
-        - go test -v -race ./...
-    - go: 1.9.x
-      script:
-        - go test -v -race ./...
-    - go: 1.10.x
-      script:
-        - go test -v -race ./...
-    - go: 1.11.x
-      script:
-        - go test -v -race ./...
-    - go: 1.12.x
-      script:
-        - go test -v -race ./...
     - go: 1.13.x
       script:
         - go test -v -race ./...

--- a/cmp/cmpopts/equate.go
+++ b/cmp/cmpopts/equate.go
@@ -6,12 +6,12 @@
 package cmpopts
 
 import (
+	"errors"
 	"math"
 	"reflect"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/xerrors"
 )
 
 func equateAlways(_, _ interface{}) bool { return true }
@@ -152,5 +152,5 @@ func compareErrors(x, y interface{}) bool {
 	xe := x.(error)
 	ye := y.(error)
 	// TODO(≥go1.13): Use standard definition of errors.Is.
-	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
+	return errors.Is(xe, ye) || errors.Is(ye, xe)
 }

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/xerrors"
 )
 
 type (
@@ -531,14 +530,14 @@ func TestOptions(t *testing.T) {
 		reason:    "user-defined EOF is not exactly equal",
 	}, {
 		label:     "EquateErrors",
-		x:         xerrors.Errorf("wrapped: %w", io.EOF),
+		x:         fmt.Errorf("wrapped: %w", io.EOF),
 		y:         io.EOF,
 		opts:      []cmp.Option{EquateErrors()},
 		wantEqual: true,
 		reason:    "wrapped io.EOF is equal according to errors.Is",
 	}, {
 		label:     "EquateErrors",
-		x:         xerrors.Errorf("wrapped: %w", io.EOF),
+		x:         fmt.Errorf("wrapped: %w", io.EOF),
 		y:         io.EOF,
 		wantEqual: false,
 		reason:    "wrapped io.EOF is not equal without EquateErrors option",
@@ -585,14 +584,14 @@ func TestOptions(t *testing.T) {
 		reason:    "user-defined EOF is not exactly equal",
 	}, {
 		label:     "EquateErrors",
-		x:         xerrors.Errorf("wrapped: %w", io.EOF),
+		x:         fmt.Errorf("wrapped: %w", io.EOF),
 		y:         io.EOF,
 		opts:      []cmp.Option{EquateErrors()},
 		wantEqual: true,
 		reason:    "wrapped io.EOF is equal according to errors.Is",
 	}, {
 		label:     "EquateErrors",
-		x:         xerrors.Errorf("wrapped: %w", io.EOF),
+		x:         fmt.Errorf("wrapped: %w", io.EOF),
 		y:         io.EOF,
 		wantEqual: false,
 		reason:    "wrapped io.EOF is not equal without EquateErrors option",
@@ -639,14 +638,14 @@ func TestOptions(t *testing.T) {
 		reason:    "user-defined EOF is not exactly equal",
 	}, {
 		label:     "EquateErrors",
-		x:         struct{ E error }{xerrors.Errorf("wrapped: %w", io.EOF)},
+		x:         struct{ E error }{fmt.Errorf("wrapped: %w", io.EOF)},
 		y:         struct{ E error }{io.EOF},
 		opts:      []cmp.Option{EquateErrors()},
 		wantEqual: true,
 		reason:    "wrapped io.EOF is equal according to errors.Is",
 	}, {
 		label:     "EquateErrors",
-		x:         struct{ E error }{xerrors.Errorf("wrapped: %w", io.EOF)},
+		x:         struct{ E error }{fmt.Errorf("wrapped: %w", io.EOF)},
 		y:         struct{ E error }{io.EOF},
 		wantEqual: false,
 		reason:    "wrapped io.EOF is not equal without EquateErrors option",

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/google/go-cmp
 
 go 1.8
-
-require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Drop the only dependency since all functionality from xerrors used in go-cmp is now merged to errors in standarad library.