### PR TITLE
Fixed panic message in IgnoreUnexported

### DIFF
--- a/cmp/cmpopts/ignore.go
+++ b/cmp/cmpopts/ignore.go
@@ -128,7 +128,7 @@ func newUnexportedFilter(typs ...interface{}) unexportedFilter {
 	for _, typ := range typs {
 		t := reflect.TypeOf(typ)
 		if t == nil || t.Kind() != reflect.Struct {
-			panic(fmt.Sprintf("invalid struct type: %T", typ))
+			panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
 		}
 		ux.m[t] = true
 	}

--- a/cmp/cmpopts/struct_filter.go
+++ b/cmp/cmpopts/struct_filter.go
@@ -42,7 +42,7 @@ func newStructFilter(typ interface{}, names ...string) structFilter {
 
 	t := reflect.TypeOf(typ)
 	if t == nil || t.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("%T must be a struct", typ))
+		panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
 	}
 	var ft fieldTree
 	for _, name := range names {

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -1223,7 +1223,7 @@ func TestPanic(t *testing.T) {
 		label:     "IgnoreFields",
 		fnc:       IgnoreFields,
 		args:      args(&Foo1{}, "Alpha"),
-		wantPanic: "must be a struct",
+		wantPanic: "must be a non-pointer struct",
 		reason:    "the type must be a struct (not pointer to a struct)",
 	}, {
 		label:  "IgnoreFields",
@@ -1304,13 +1304,13 @@ func TestPanic(t *testing.T) {
 		label:     "IgnoreUnexported",
 		fnc:       IgnoreUnexported,
 		args:      args(nil),
-		wantPanic: "invalid struct type",
+		wantPanic: "must be a non-pointer struct",
 		reason:    "input must not be nil value",
 	}, {
 		label:     "IgnoreUnexported",
 		fnc:       IgnoreUnexported,
 		args:      args(&Foo1{}),
-		wantPanic: "invalid struct type",
+		wantPanic: "must be a non-pointer struct",
 		reason:    "input must be a struct type (not a pointer to a struct)",
 	}, {
 		label:  "IgnoreUnexported",


### PR DESCRIPTION
Fixed panic message more specifically.
With this fix, you can see that IgnoreUnexported only supports a struct without the user having to look at the code.