### PR TITLE
cmp/cmpopts: use errors.Is with ≥go1.13 in compareErrors

### DIFF
--- a/cmp/cmpopts/equate.go
+++ b/cmp/cmpopts/equate.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"golang.org/x/xerrors"
 )
 
 func equateAlways(_, _ interface{}) bool { return true }
@@ -146,11 +145,4 @@ func areConcreteErrors(x, y interface{}) bool {
 	_, ok1 := x.(error)
 	_, ok2 := y.(error)
 	return ok1 && ok2
-}
-
-func compareErrors(x, y interface{}) bool {
-	xe := x.(error)
-	ye := y.(error)
-	// TODO(≥go1.13): Use standard definition of errors.Is.
-	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
 }

--- a/cmp/cmpopts/errors_go113.go
+++ b/cmp/cmpopts/errors_go113.go
@@ -1,0 +1,15 @@
+// Copyright 2021, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.13
+
+package cmpopts
+
+import "errors"
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	return errors.Is(xe, ye) || errors.Is(ye, xe)
+}

--- a/cmp/cmpopts/errors_xerrors.go
+++ b/cmp/cmpopts/errors_xerrors.go
@@ -1,0 +1,18 @@
+// Copyright 2021, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.13
+
+// TODO(≥go1.13): For support on <go1.13, we use the xerrors package.
+// Drop this file when we no longer support older Go versions.
+
+package cmpopts
+
+import "golang.org/x/xerrors"
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
+}


### PR DESCRIPTION
Use the standard definition of errors.Is to implement compareErrors with
≥go1.13. Retain the implementation using golang.org/x/xerrors for versions <go1.13.

This will allow packages using newer Go versions and already relying on
the errors package to get rid of the transitive dependency on
golang.org/x/xerrors.