### PR TITLE
Run tests on Go 1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     strategy:
       matrix:
-        go-version: [1.8.x, 1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.8.x, 1.9.x, 1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x, 1.16.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -26,5 +26,5 @@ jobs:
     - name: Test
       run: go test -v -race ./...
     - name: Format
-      if: matrix.go-version == '1.15.x'
+      if: matrix.go-version == '1.16.x'
       run: diff -u <(echo -n) <(gofmt -d .)


### PR DESCRIPTION
Add Go 1.16 to the GitHub actions test coverage matrix.

Also switch the `gofmt` check to only run on Go 1.16, i.e. the latest
supported version.