### PR TITLE
Avoid shadowing variable

### DIFF
--- a/cmp/report_slices.go
+++ b/cmp/report_slices.go
@@ -563,10 +563,10 @@ func cleanupSurroundingIdentical(groups []diffStats, eq func(i, j int) bool) []d
 		nx := ds.NumIdentical + ds.NumRemoved + ds.NumModified
 		ny := ds.NumIdentical + ds.NumInserted + ds.NumModified
 		var numLeadingIdentical, numTrailingIdentical int
-		for i := 0; i < nx && i < ny && eq(ix+i, iy+i); i++ {
+		for j := 0; j < nx && j < ny && eq(ix+j, iy+j); j++ {
 			numLeadingIdentical++
 		}
-		for i := 0; i < nx && i < ny && eq(ix+nx-1-i, iy+ny-1-i); i++ {
+		for j := 0; j < nx && j < ny && eq(ix+nx-1-j, iy+ny-1-j); j++ {
 			numTrailingIdentical++
 		}
 		if numIdentical := numLeadingIdentical + numTrailingIdentical; numIdentical > 0 {


### PR DESCRIPTION
Rename the shadowed variable i to j for better readability.