### PR TITLE
Add //go:build lines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
     - name: Test
       run: go test -v -race ./...
     - name: Format
-      if: matrix.go-version == '1.16.x'
+      if: matrix.go-version == '1.17.x'
       run: diff -u <(echo -n) <(gofmt -d .)

--- a/cmp/cmpopts/errors_go113.go
+++ b/cmp/cmpopts/errors_go113.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.13
 // +build go1.13
 
 package cmpopts

--- a/cmp/cmpopts/errors_xerrors.go
+++ b/cmp/cmpopts/errors_xerrors.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !go1.13
 // +build !go1.13
 
 // TODO(≥go1.13): For support on <go1.13, we use the xerrors package.

--- a/cmp/export_panic.go
+++ b/cmp/export_panic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build purego
 // +build purego
 
 package cmp

--- a/cmp/export_unsafe.go
+++ b/cmp/export_unsafe.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !purego
 // +build !purego
 
 package cmp

--- a/cmp/internal/diff/debug_disable.go
+++ b/cmp/internal/diff/debug_disable.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !cmp_debug
 // +build !cmp_debug
 
 package diff

--- a/cmp/internal/diff/debug_enable.go
+++ b/cmp/internal/diff/debug_enable.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build cmp_debug
 // +build cmp_debug
 
 package diff

--- a/cmp/internal/value/pointer_purego.go
+++ b/cmp/internal/value/pointer_purego.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build purego
 // +build purego
 
 package value

--- a/cmp/internal/value/pointer_unsafe.go
+++ b/cmp/internal/value/pointer_unsafe.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !purego
 // +build !purego
 
 package value


### PR DESCRIPTION
Starting with Go 1.17, //go:build lines are preferred over // +build
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 go fmt ./... which
automatically adds //go:build lines based on the existing // +build
lines.

Also update the corresponding GitHub action to use Go 1.17 gofmt.