### PR TITLE
Special-case for top-level triple-quoted string literals

### DIFF
--- a/cmp/compare_test.go
+++ b/cmp/compare_test.go
@@ -1125,6 +1125,18 @@ func reporterTests() []test {
 		wantEqual: false,
 		reason:    "use triple-quote syntax",
 	}, {
+		label:     label + "/TripleQuoteEndlines/MyString",
+		x:         MyString("aaa\nbbb\nccc\nddd\neee\nfff\nggg\r\nhhh\n\riii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nRRR\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz\n\r"),
+		y:         MyString("aaa\nbbb\nCCC\nddd\neee\nfff\nggg\r\nhhh\n\riii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nrrr\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz"),
+		wantEqual: false,
+		reason:    "use triple-quote syntax",
+	}, {
+		label:     label + "/TripleQuoteEndlines/Bytes",
+		x:         []byte("aaa\nbbb\nccc\nddd\neee\nfff\nggg\r\nhhh\n\riii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nRRR\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz\n\r"),
+		y:         []byte("aaa\nbbb\nCCC\nddd\neee\nfff\nggg\r\nhhh\n\riii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nrrr\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz"),
+		wantEqual: false,
+		reason:    "use triple-quote syntax",
+	}, {
 		label:     label + "/AvoidTripleQuoteAmbiguousQuotes",
 		x:         "aaa\nbbb\nccc\nddd\neee\nfff\nggg\nhhh\niii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nRRR\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz\n",
 		y:         "aaa\nbbb\nCCC\nddd\neee\n\"\"\"\nggg\nhhh\niii\njjj\nkkk\nlll\nmmm\nnnn\nooo\nppp\nqqq\nrrr\nsss\nttt\nuuu\nvvv\nwww\nxxx\nyyy\nzzz\n",

--- a/cmp/testdata/diffs
+++ b/cmp/testdata/diffs
@@ -626,7 +626,28 @@
   }
 >>> TestDiff/Reporter/TripleQuoteSliceNamedTypes
 <<< TestDiff/Reporter/TripleQuoteEndlines
-  (
+  """
+  aaa
+  bbb
+- ccc
++ CCC
+  ddd
+  eee
+  ... // 10 identical lines
+  ppp
+  qqq
+- RRR
++ rrr
+  sss
+  ttt
+  ... // 4 identical lines
+  yyy
+  zzz
+- 
+  """
+>>> TestDiff/Reporter/TripleQuoteEndlines
+<<< TestDiff/Reporter/TripleQuoteEndlines/MyString
+  cmp_test.MyString(
   	"""
   	aaa
   	bbb
@@ -647,7 +668,30 @@
 - 	
   	"""
   )
->>> TestDiff/Reporter/TripleQuoteEndlines
+>>> TestDiff/Reporter/TripleQuoteEndlines/MyString
+<<< TestDiff/Reporter/TripleQuoteEndlines/Bytes
+  []uint8(
+  	"""
+  	aaa
+  	bbb
+- 	ccc
++ 	CCC
+  	ddd
+  	eee
+  	... // 10 identical lines
+  	ppp
+  	qqq
+- 	RRR
++ 	rrr
+  	sss
+  	ttt
+  	... // 4 identical lines
+  	yyy
+  	zzz
+- 	
+  	"""
+  )
+>>> TestDiff/Reporter/TripleQuoteEndlines/Bytes
 <<< TestDiff/Reporter/AvoidTripleQuoteAmbiguousQuotes
   strings.Join({
   	"aaa",
@@ -817,58 +861,56 @@
   }
 >>> TestDiff/Reporter/LimitMaximumBytesDiffs
 <<< TestDiff/Reporter/LimitMaximumStringDiffs
-  (
-  	"""
-- 	a
-+ 	aa
-  	b
-- 	c
-+ 	cc
-  	d
-- 	e
-+ 	ee
-  	f
-- 	g
-+ 	gg
-  	h
-- 	i
-+ 	ii
-  	j
-- 	k
-+ 	kk
-  	l
-- 	m
-+ 	mm
-  	n
-- 	o
-+ 	oo
-  	p
-- 	q
-+ 	qq
-  	r
-- 	s
-+ 	ss
-  	t
-- 	u
-+ 	uu
-  	v
-- 	w
-+ 	ww
-  	x
-- 	y
-+ 	yy
-  	z
-- 	A
-+ 	AA
-  	B
-- 	C
-+ 	CC
-  	D
-- 	E
-+ 	EE
-  	... // 12 identical, 10 removed, and 10 inserted lines
-  	"""
-  )
+  """
+- a
++ aa
+  b
+- c
++ cc
+  d
+- e
++ ee
+  f
+- g
++ gg
+  h
+- i
++ ii
+  j
+- k
++ kk
+  l
+- m
++ mm
+  n
+- o
++ oo
+  p
+- q
++ qq
+  r
+- s
++ ss
+  t
+- u
++ uu
+  v
+- w
++ ww
+  x
+- y
++ yy
+  z
+- A
++ AA
+  B
+- C
++ CC
+  D
+- E
++ EE
+  ... // 12 identical, 10 removed, and 10 inserted lines
+  """
 >>> TestDiff/Reporter/LimitMaximumStringDiffs
 <<< TestDiff/Reporter/LimitMaximumSliceDiffs
   []struct{ S string }{
@@ -1123,16 +1165,14 @@
   }
 >>> TestDiff/Reporter/NonStringifiedNamedBytes
 <<< TestDiff/Reporter/ShortJSON
-  (
-  	"""
-  	{
-- 		"id": 1,
-+ 		"id": 1434180,
-  		"foo": true,
-  		"bar": true,
-  	}
-  	"""
-  )
+  """
+  {
+- 	"id": 1,
++ 	"id": 1434180,
+  	"foo": true,
+  	"bar": true,
+  }
+  """
 >>> TestDiff/Reporter/ShortJSON
 <<< TestDiff/Reporter/PointerToStringOrAny
   any(


### PR DESCRIPTION
For top-level triple-quoted string literals, the surrounding parenthesis
is an unnecessary amount of verbosity and indentation.
These parenthesis are always needed for any situation where the triple-quoted
string literal does not appear at the top-level to ensure that it nests well
within some other composite structure.

Thus, we detect triple-quoted string literals at the top-level
and format them verbatim. The textList.formatExpandedTo method
assumes that it is usually called within the context of a composite structure,
so we perform some string mangling to correct the leading and trailing bytes.

Fixes #301