### PR TITLE
Do not inhibit the dead code elimination.

### DIFF
--- a/cmp/path.go
+++ b/cmp/path.go
@@ -168,7 +168,9 @@ func (ps pathStep) String() string {
 	if ps.typ == nil {
 		return "<nil>"
 	}
-	s := value.TypeString(ps.typ, false)
+	// NOTE: do not use value.TypeString(qualified = false) to avoid
+	// calls to reflect.Type.Method() which disables the DCE.
+	s := ps.typ.String()
 	if s == "" || strings.ContainsAny(s, "{}\n") {
 		return "root" // Type too simple or complex to print
 	}
@@ -293,7 +295,11 @@ type typeAssertion struct {
 
 func (ta TypeAssertion) Type() reflect.Type             { return ta.typ }
 func (ta TypeAssertion) Values() (vx, vy reflect.Value) { return ta.vx, ta.vy }
-func (ta TypeAssertion) String() string                 { return fmt.Sprintf(".(%v)", value.TypeString(ta.typ, false)) }
+func (ta TypeAssertion) String() string {
+	// NOTE: do not use value.TypeString(qualified = false) to avoid
+	// calls to reflect.Type.Method() which disables the DCE.
+	return fmt.Sprintf(".(%v)", ta.typ.String())
+}
 
 // Transform is a [PathStep] that represents a transformation
 // from the parent type to the current type.


### PR DESCRIPTION
Avoid calls to value.TypeString() that do not request fully qualified type names. The implementation of TypeString() depends on getting methods by index which disables the DCE in the compiler.

k8s.io/kube-openapi and k8s.io/apiserver happen to depend on go-cmp outside tests so it is important that go-cmp does not inhibit the DCE inadvertently.