### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #347 

Here is a dependabot configuration that enables version updates for github workflows and groups them in a single PR to avoid multiple PRs

It is schedule to run monthly to allow a delay after new version bumps to allow vulnerabilities to be discovered and fixed before affecting go-cmp. Because of that, it is important to enable the "security updates" on the config, mentioned in the issue, because it enables dependabot to send out of schedule PRs in case of a security patch being released.