### PR TITLE
Support compare functions with SortSlices and SortMaps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -131,6 +131,23 @@ func TestOptions(t *testing.T) {
 		wantEqual: true,
 		reason:    "equal because SortSlices sorts the slices",
 	}, {
+		label: "SortSlices",
+		x:     []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		y:     []int{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
+		opts: []cmp.Option{SortSlices(func(x, y int) int {
+			// TODO(Go1.22): Use cmp.Compare.
+			switch {
+			case x < y:
+				return -1
+			case y > x:
+				return +1
+			default:
+				return 0
+			}
+		})},
+		wantEqual: true,
+		reason:    "equal because SortSlices sorts the slices",
+	}, {
 		label:     "SortSlices",
 		x:         []MyInt{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		y:         []MyInt{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
@@ -199,6 +216,21 @@ func TestOptions(t *testing.T) {
 			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "2nd birthday",
 		},
 		opts:      []cmp.Option{SortMaps(func(x, y time.Time) bool { return x.Before(y) })},
+		wantEqual: true,
+		reason:    "equal because SortMaps flattens to a slice where Time.Equal can be used",
+	}, {
+		label: "SortMaps",
+		x: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC): "2nd birthday",
+		},
+		y: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "2nd birthday",
+		},
+		opts:      []cmp.Option{SortMaps(func(x, y time.Time) int { return time.Time.Compare(x, y) })},
 		wantEqual: true,
 		reason:    "equal because SortMaps flattens to a slice where Time.Equal can be used",
 	}, {
@@ -1187,26 +1219,14 @@ func TestPanic(t *testing.T) {
 	}, {
 		label:     "SortSlices",
 		fnc:       SortSlices,
-		args:      args(strings.Compare),
-		wantPanic: "invalid less function",
-		reason:    "func(x, y string) int is wrong signature for less",
-	}, {
-		label:     "SortSlices",
-		fnc:       SortSlices,
 		args:      args((func(_, _ int) bool)(nil)),
-		wantPanic: "invalid less function",
+		wantPanic: "invalid less or compare function",
 		reason:    "nil value is not valid",
 	}, {
 		label:     "SortMaps",
 		fnc:       SortMaps,
-		args:      args(strings.Compare),
-		wantPanic: "invalid less function",
-		reason:    "func(x, y string) int is wrong signature for less",
-	}, {
-		label:     "SortMaps",
-		fnc:       SortMaps,
 		args:      args((func(_, _ int) bool)(nil)),
-		wantPanic: "invalid less function",
+		wantPanic: "invalid less or compare function",
 		reason:    "nil value is not valid",
 	}, {
 		label:     "IgnoreFields",

--- a/cmp/internal/function/func.go
+++ b/cmp/internal/function/func.go
@@ -19,6 +19,7 @@ const (
 
 	tbFunc  // func(T) bool
 	ttbFunc // func(T, T) bool
+	ttiFunc // func(T, T) int
 	trbFunc // func(T, R) bool
 	tibFunc // func(T, I) bool
 	trFunc  // func(T) R
@@ -28,11 +29,13 @@ const (
 	Transformer       = trFunc  // func(T) R
 	ValueFilter       = ttbFunc // func(T, T) bool
 	Less              = ttbFunc // func(T, T) bool
+	Compare           = ttiFunc // func(T, T) int
 	ValuePredicate    = tbFunc  // func(T) bool
 	KeyValuePredicate = trbFunc // func(T, R) bool
 )
 
 var boolType = reflect.TypeOf(true)
+var intType = reflect.TypeOf(0)
 
 // IsType reports whether the reflect.Type is of the specified function type.
 func IsType(t reflect.Type, ft funcType) bool {
@@ -47,6 +50,10 @@ func IsType(t reflect.Type, ft funcType) bool {
 		}
 	case ttbFunc: // func(T, T) bool
 		if ni == 2 && no == 1 && t.In(0) == t.In(1) && t.Out(0) == boolType {
+			return true
+		}
+	case ttiFunc: // func(T, T) int
+		if ni == 2 && no == 1 && t.In(0) == t.In(1) && t.Out(0) == intType {
 			return true
 		}
 	case trbFunc: // func(T, R) bool

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/go-cmp
 
-go 1.13
+go 1.21


### PR DESCRIPTION
The SortSlices and SortMaps options predate generics and
accept an interface{}, so it is possible with reflection to support other function signatures than "func(T, T) bool".

In particular, the Go ecosystem is increasingly moving towards "func(T, T) int" as the signature for ordering as evidenced by the newer slices.SortFunc function in stdlib.

Thus, modernize cmpopts by supporting "func(T, T) int".

Fixes #365