### PR TITLE
Add a build tag to avoid disabling dead code elimination

### DIFF
--- a/cmp/internal/value/name.go
+++ b/cmp/internal/value/name.go
@@ -136,27 +136,31 @@ func appendTypeName(b []byte, t reflect.Type, qualified, elideFunc bool) []byte 
 		b = append(b, '*')
 		b = appendTypeName(b, t.Elem(), qualified, false)
 	case reflect.Interface:
-		b = append(b, "interface{ "...)
-		for i := 0; i < t.NumMethod(); i++ {
-			if i > 0 {
-				b = append(b, "; "...)
-			}
-			m := t.Method(i)
-			if qualified && m.PkgPath != "" {
-				b = append(b, '"')
-				b = append(b, m.PkgPath...)
-				b = append(b, '"')
-				b = append(b, '.')
-			}
-			b = append(b, m.Name...)
-			b = appendTypeName(b, m.Type, qualified, true)
-		}
-		if b[len(b)-1] == ' ' {
-			b = b[:len(b)-1]
+		if interfaceStringNoReflect {
+			b = append(b, t.String()...)
 		} else {
-			b = append(b, ' ')
+			b = append(b, "interface{ "...)
+			for i := 0; i < t.NumMethod(); i++ {
+				if i > 0 {
+					b = append(b, "; "...)
+				}
+				m := t.Method(i)
+				if qualified && m.PkgPath != "" {
+					b = append(b, '"')
+					b = append(b, m.PkgPath...)
+					b = append(b, '"')
+					b = append(b, '.')
+				}
+				b = append(b, m.Name...)
+				b = appendTypeName(b, m.Type, qualified, true)
+			}
+			if b[len(b)-1] == ' ' {
+				b = b[:len(b)-1]
+			} else {
+				b = append(b, ' ')
+			}
+			b = append(b, '}')
 		}
-		b = append(b, '}')
 	default:
 		panic("invalid kind: " + k.String())
 	}

--- a/cmp/internal/value/name_interface.go
+++ b/cmp/internal/value/name_interface.go
@@ -1,0 +1,9 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !interface_string_no_reflect
+
+package value
+
+const interfaceStringNoReflect bool = false

--- a/cmp/internal/value/name_interface_no_reflect.go
+++ b/cmp/internal/value/name_interface_no_reflect.go
@@ -1,0 +1,9 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build interface_string_no_reflect
+
+package value
+
+const interfaceStringNoReflect bool = true


### PR DESCRIPTION
Fixes https://github.com/google/go-cmp/issues/373.

This PR moves creating the string representation of an unnamed interface behind a build tag `interface_string_no_reflect`.
- When the build tag is not used, nothing changes.
- When the build tag is used, just use `reflect.Type.String()` to get the string representation of the type. The main caveat of this implementation is that it ignores the `qualified` argument.

**Additional notes**
This works because the compiler can determine that one branch of the condition is not reachable, due to using a constant and not a variable.