### PR TITLE
Update readme to mention only using in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 This package is intended to be a more powerful and safer alternative to
 `reflect.DeepEqual` for comparing whether two values are semantically equal.
 
+It is intended to only be used in tests, as performance is not a goal and
+it may panic if it cannot compare the values. Its propensity towards
+panicking means that its unsuitable for production environments where a
+spurious panic may be fatal.
+
 The primary features of `cmp` are:
 
 * When the default behavior of equality does not suit the needs of the test,


### PR DESCRIPTION
Add the text added in https://github.com/google/go-cmp/pull/189 to the README.

The goal is to make it clearer that go-cmp is only supposed to be used in tests, and what the caveats are.