### PR TITLE
Fix typo in comment (embedding)

### DIFF
--- a/cmp/cmpopts/struct_filter.go
+++ b/cmp/cmpopts/struct_filter.go
@@ -165,7 +165,7 @@ func canonicalName(t reflect.Type, sel string) ([]string, error) {
 	sf, _ := t.FieldByName(name)
 	if !isExported(name) {
 		// Avoid using reflect.Type.FieldByName for unexported fields due to
-		// buggy behavior with regard to embeddeding and unexported fields.
+		// buggy behavior with regard to embedding and unexported fields.
 		// See https://golang.org/issue/4876 for details.
 		sf = reflect.StructField{}
 		for i := 0; i < t.NumField() && sf.Name == ""; i++ {


### PR DESCRIPTION
I was checking this library because I want to replace `reflect.DeepEqual` to `cmp.Equal` or `cmp.Diff` and while doing so, I saw that there is a typo in the word `embedding` in one of the doc comments.

I believe it has no impact at all in the code since it's just a change in a comment.

Cheers.