### PR TITLE
docs: clarify Equal method is skipped when either value is nil

### DIFF
--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -58,10 +58,9 @@ import (
 //
 //   - If the values have an Equal method of the form "(T) Equal(T) bool" or
 //     "(T) Equal(I) bool" where T is assignable to I, then use the result of
-//     x.Equal(y) when both values are non-nil. If either value is nil, Equal
-//     reports whether both are nil without calling the method (so a nil
-//     receiver never panics). Otherwise, no such method exists and evaluation
-//     proceeds to the next rule.
+//     x.Equal(y). The method is called even if x or y are nil and Equal
+//     is declared on a pointer receiver. Otherwise, no such method exists and
+//     evaluation proceeds to the next rule.
 //
 //   - Lastly, try to compare x and y based on their basic kinds.
 //     Simple kinds like booleans, integers, floats, complex numbers, strings,

--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -58,8 +58,10 @@ import (
 //
 //   - If the values have an Equal method of the form "(T) Equal(T) bool" or
 //     "(T) Equal(I) bool" where T is assignable to I, then use the result of
-//     x.Equal(y) even if x or y is nil. Otherwise, no such method exists and
-//     evaluation proceeds to the next rule.
+//     x.Equal(y) when both values are non-nil. If either value is nil, Equal
+//     reports whether both are nil without calling the method (so a nil
+//     receiver never panics). Otherwise, no such method exists and evaluation
+//     proceeds to the next rule.
 //
 //   - Lastly, try to compare x and y based on their basic kinds.
 //     Simple kinds like booleans, integers, floats, complex numbers, strings,


### PR DESCRIPTION
## Summary
Package docs for `Equal` said the method is used **even if x or y is nil**.

Actual behavior: `comparePtr` / `compareInterface` report nil equality first and return, so `tryMethod` never runs when either side is nil. Non-nil values still call `Equal` as documented.

This matches issue #363 and avoids implying a nil receiver would be invoked (and potentially panic).

## Test plan
- [x] Manual repro: nil vs non-nil `*T` with value-receiver `Equal` does not print / call method
- [x] `go test ./cmp/`

Fixes #363
