### PR TITLE
cmp: avoid time.Location initialization race in reports

### DIFF
--- a/cmp/report_reflect.go
+++ b/cmp/report_reflect.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -21,6 +22,7 @@ var (
 	stringType = reflect.TypeOf((*string)(nil)).Elem()
 	bytesType  = reflect.TypeOf((*[]byte)(nil)).Elem()
 	byteType   = reflect.TypeOf((*byte)(nil)).Elem()
+	timeType   = reflect.TypeOf(time.Time{})
 )
 
 type formatValueOptions struct {
@@ -116,6 +118,11 @@ func (opts formatOptions) FormatValue(v reflect.Value, parentKind reflect.Kind, 
 		return nil
 	}
 	t := v.Type()
+	if opts.AvoidStringer && t == timeType {
+		// A time.Location is initialized lazily. Synchronize with the location
+		// referenced by this value before reflecting over its unexported fields.
+		_ = v.Interface().(time.Time).Location().String()
+	}
 
 	// Check slice element for cycles.
 	if parentKind == reflect.Slice {

--- a/cmp/report_reflect_test.go
+++ b/cmp/report_reflect_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmp
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFormatMapKeyDisambiguatesTimeLocations(t *testing.T) {
+	utc := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	fixed := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.FixedZone("UTC", 0))
+	if utc == fixed {
+		t.Fatal("test requires time values with distinct location pointers")
+	}
+	if utc.String() != fixed.String() {
+		t.Fatal("test requires time values with identical String output")
+	}
+
+	utcKey := formatMapKey(reflect.ValueOf(utc), true, new(pointerReferences))
+	fixedKey := formatMapKey(reflect.ValueOf(fixed), true, new(pointerReferences))
+	if utcKey == fixedKey {
+		t.Fatalf("formatMapKey returned identical output for distinct keys: %q", utcKey)
+	}
+}

--- a/cmp/time_race_test.go
+++ b/cmp/time_race_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build race
+
+package cmp_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const timeLocalRaceHelper = "GO_CMP_TIME_LOCAL_RACE_HELPER"
+
+type timeRaceStringer struct{}
+
+func (timeRaceStringer) String() string { return "" }
+
+type timeRaceResource struct {
+	timeRaceStringer
+	WitnessedTime time.Time
+}
+
+func (r *timeRaceResource) clone() *timeRaceResource {
+	r2 := *r
+	return &r2
+}
+
+func TestDiffDoesNotRaceWithTimeLocalInitialization(t *testing.T) {
+	if os.Getenv(timeLocalRaceHelper) == "1" {
+		runTimeLocalRaceHelper()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDiffDoesNotRaceWithTimeLocalInitialization$")
+	cmd.Env = append(os.Environ(), timeLocalRaceHelper+"=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("race helper failed: %v\n%s", err, out)
+	}
+}
+
+func runTimeLocalRaceHelper() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	witnessedTime := time.Now()
+	// Ensure synchronizing the current time.Local is insufficient: witnessedTime
+	// still refers to the original lazily initialized local location.
+	time.Local = time.FixedZone("replacement", 0)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			r := timeRaceResource{WitnessedTime: witnessedTime}
+			if diff := cmp.Diff(r, r.clone()); diff == "" {
+				panic(fmt.Sprintf("cmp.Diff(%T, %T) returned an empty diff", r, r.clone()))
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			_ = witnessedTime.AppendFormat(nil, "")
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

When `cmp.Diff` produces a high-verbosity report that avoids `String` methods, it can reflect over the unexported fields of a `time.Time`. If the referenced `time.Location` is being lazily initialized at the same time, the report races with the standard library's initialization writes.

This is the reporting race described in #381 and golang/go#74460.

## Root cause

The fallback report bypasses `fmt.Stringer` so it can expose otherwise hidden differences. For `time.Time`, that means recursively reading its private `Location` state without first synchronizing with lazy location initialization.

## Change

Before reflectively formatting a `time.Time` with Stringer formatting disabled, initialize the specific `Location` referenced by that value. This keeps the existing reflective output, including map-key disambiguation, while avoiding concurrent reads during lazy initialization.

The regression coverage:

- runs the race scenario in a fresh child process so the location starts uninitialized;
- replaces the global `time.Local` after constructing the value, verifying that the value's actual location is synchronized;
- verifies that distinct `time.Time` map keys with identical `String` output remain distinguishable.

## Verification

- `GOCACHE=/tmp/go-cmp-cache-regression go test -race ./cmp -run '^TestDiffDoesNotRaceWithTimeLocalInitialization$' -count=5` — pass
- `GOCACHE=/tmp/go-cmp-cache-target go test ./cmp -run '^TestFormatMapKeyDisambiguatesTimeLocations$' -count=3` — pass
- `GOCACHE=/tmp/go-cmp-cache-race go test -race ./...` — pass
- `test -z "$(gofmt -d .)"` — pass
- `git diff --check HEAD^ HEAD` — pass

## Compatibility and risk

There is no public API change. The special case only runs when report formatting intentionally bypasses Stringer methods; ordinary `time.Time` formatting and comparison behavior are unchanged.

Fixes #381.
