### PR TITLE
cmp/cmpopts: prevent nil pointer dereference on nil value in EquateComparable

### DIFF
--- a/cmp/cmpopts/equate.go
+++ b/cmp/cmpopts/equate.go
@@ -167,7 +167,7 @@ func EquateComparable(typs ...any) cmp.Option {
 	types := make(typesFilter)
 	for _, typ := range typs {
 		switch t := reflect.TypeOf(typ); {
-		case !t.Comparable():
+		case t == nil || !t.Comparable():
 			panic(fmt.Sprintf("%T is not a comparable Go type", typ))
 		case types[t]:
 			panic(fmt.Sprintf("%T is already specified", typ))

--- a/cmp/cmpopts/util_test.go
+++ b/cmp/cmpopts/util_test.go
@@ -1368,6 +1368,18 @@ func TestPanic(t *testing.T) {
 		args:   args(Foo1{}, struct{ x, X int }{}),
 		reason: "input may be named or unnamed structs",
 	}, {
+		label:     "EquateComparable",
+		fnc:       EquateComparable,
+		args:      args(nil),
+		wantPanic: "is not a comparable Go type",
+		reason:    "nil value is not a comparable Go type",
+	}, {
+		label:     "EquateComparable",
+		fnc:       EquateComparable,
+		args:      args(func() {}),
+		wantPanic: "is not a comparable Go type",
+		reason:    "func is not a comparable Go type",
+	}, {
 		label:     "AcyclicTransformer",
 		fnc:       AcyclicTransformer,
 		args:      args("", "not a func"),


### PR DESCRIPTION
### Problem
In `EquateComparable`, passing an untyped `nil` value results in `reflect.TypeOf(typ)` returning `nil`. Attempting to call `t.Comparable()` directly on `nil` leads to an unhandled runtime nil pointer dereference panic.

### Solution
- Guard against `t == nil` in `EquateComparable` before calling `t.Comparable()`, raising the formatted panic message consistently.
- Add test cases in `util_test.go` for invalid inputs (`nil` and non-comparable function).